### PR TITLE
PYMT-789 custom request denormalizer mapping

### DIFF
--- a/src/Exceptions/DoctrineDenormalizerMappingException.php
+++ b/src/Exceptions/DoctrineDenormalizerMappingException.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Exceptions;
+
+use EoneoPay\Utils\Exceptions\BaseException;
+
+class DoctrineDenormalizerMappingException extends BaseException
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorCode(): int
+    {
+        return 30;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorSubCode(): int
+    {
+        return 1;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStatusCode(): int
+    {
+        return static::DEFAULT_STATUS_CODE_RUNTIME;
+    }
+}

--- a/src/Serializer/DoctrineDenormalizer.php
+++ b/src/Serializer/DoctrineDenormalizer.php
@@ -12,6 +12,8 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
  */
 class DoctrineDenormalizer implements DenormalizerInterface
 {
+    private $findKeyMap;
+
     /**
      * @var \Doctrine\Common\Persistence\ManagerRegistry
      */
@@ -22,9 +24,10 @@ class DoctrineDenormalizer implements DenormalizerInterface
      *
      * @param \Doctrine\Common\Persistence\ManagerRegistry $managerRegistry
      */
-    public function __construct(ManagerRegistry $managerRegistry)
+    public function __construct(ManagerRegistry $managerRegistry, ?array $findKeyMap = null)
     {
         $this->managerRegistry = $managerRegistry;
+        $this->findKeyMap = $findKeyMap;
     }
 
     /**
@@ -38,6 +41,14 @@ class DoctrineDenormalizer implements DenormalizerInterface
             // of deserialize
 
             return $data;
+        }
+
+        // find key from provided mapping
+        $findKey = $this->getFindByKey($class);
+
+        if ($findKey !== null) {
+            return $this->managerRegistry->getRepository($class)
+                ->findOneBy([$findKey => $data[$findKey]]);
         }
 
         if (($data['id'] ?? null) === null) {
@@ -59,5 +70,25 @@ class DoctrineDenormalizer implements DenormalizerInterface
         }
 
         return $manager->getMetadataFactory()->isTransient($type) === false;
+    }
+
+    /**
+     * Get find by key from provided mappings.
+     *
+     * @param $class
+     *
+     * @return bool|null
+     */
+    public function getFindByKey($class): ?string
+    {
+        if ($this->findKeyMap === null) {
+            return null;
+        }
+
+        if (\array_key_exists($class, $this->findKeyMap) !== true) {
+            return null;
+        }
+
+        return $this->findKeyMap[$class];
     }
 }

--- a/src/Serializer/DoctrineDenormalizer.php
+++ b/src/Serializer/DoctrineDenormalizer.php
@@ -126,6 +126,6 @@ class DoctrineDenormalizer implements DenormalizerInterface
             throw new DoctrineDenormalizerMappingException('Mis-configured class-key mappings in denormalizer.');
         }
 
-        return $keyMap;
+        return \array_merge($default, $keyMap);
     }
 }

--- a/src/Serializer/DoctrineDenormalizer.php
+++ b/src/Serializer/DoctrineDenormalizer.php
@@ -97,9 +97,9 @@ class DoctrineDenormalizer implements DenormalizerInterface
      *
      * @param string $class Class name
      *
-     * @return string|null
+     * @return mixed|null
      */
-    private function getClassLookupKey(string $class): ?string
+    private function getClassLookupKey(string $class)
     {
         if ($this->classKeyMap === null) {
             return null;

--- a/tests/Exceptions/DoctrineDenormalizerMappingExceptionTest.php
+++ b/tests/Exceptions/DoctrineDenormalizerMappingExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Exceptions;
+
+use LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerMappingException;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerMappingException
+ */
+class DoctrineDenormalizerMappingExceptionTest extends TestCase
+{
+    /**
+     * Tests methods on DoctrineDenormalizerMappingException
+     *
+     * @return void
+     */
+    public function testExceptionMethods(): void
+    {
+        $exception = new DoctrineDenormalizerMappingException();
+
+        self::assertSame(1, $exception->getErrorSubCode());
+        self::assertSame(30, $exception->getErrorCode());
+        self::assertSame(500, $exception->getStatusCode());
+    }
+}


### PR DESCRIPTION
`DoctrineDenormalizer` now optionally accepts class-key mapping as array in its constructor for custom entity lookup (`findOneBy`).

