### PR TITLE
PYMT-900 request handlers improvements

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -47,3 +47,6 @@ parameters:
         -
             message: '#Call to static method PHPUnit\\Framework\\Assert::assertInstanceOf\(\) with (.*) and Symfony\\Component\\Serializer\\Exception\\NotNormalizableValueException will always evaluate to true\.#'
             path: tests/Serializer/RequestBodySerializerTest.php
+        -
+            message: '#Cannot access offset 2 on object\|string\.#'
+            path: tests/Integration/RequestIntegrationTest.php

--- a/src/Bridge/Laravel/Providers/ParamConverterProvider.php
+++ b/src/Bridge/Laravel/Providers/ParamConverterProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace LoyaltyCorp\RequestHandlers\Bridge\Laravel\Providers;
 
 use DateTime;
+use DateTimeZone;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use EoneoPay\Utils\AnnotationReader;
@@ -170,7 +171,7 @@ final class ParamConverterProvider extends ServiceProvider
         $this->app->singleton(DateTimeNormalizer::class, static function (Container $app): DateTimeNormalizer {
             return new DateTimeNormalizer([
                 DateTimeNormalizer::FORMAT_KEY => DateTime::RFC3339
-            ]);
+            ], new DateTimeZone('UTC'));
         });
         $this->app->singleton(DoctrineDenormalizer::class);
         $this->app->singleton(PropertyNormalizer::class, static function (Container $app): PropertyNormalizer {

--- a/src/Exceptions/InvalidContentTypeException.php
+++ b/src/Exceptions/InvalidContentTypeException.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Exceptions;
+
+use EoneoPay\Utils\Exceptions\RuntimeException;
+
+class InvalidContentTypeException extends RuntimeException
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorCode(): int
+    {
+        return 40;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorSubCode(): int
+    {
+        return 1;
+    }
+}

--- a/src/Middleware/ParamConverterMiddleware.php
+++ b/src/Middleware/ParamConverterMiddleware.php
@@ -69,7 +69,7 @@ final class ParamConverterMiddleware
 
         // Add laravel route attributes to the symfony request attribute bag so the
         // symfony dependencies will work as expected.
-        $request->attributes->add($route[2]);
+        $request->attributes->add($route[2] ?? []);
 
         // Create a faux FilterControllerEvent for use in the symfony dependencies below.
         $filterController = new FilterControllerEvent($controller, $request);

--- a/src/Middleware/ValidatingMiddleware.php
+++ b/src/Middleware/ValidatingMiddleware.php
@@ -44,7 +44,7 @@ final class ValidatingMiddleware
         }
 
         /** @noinspection ForeachSourceInspection Laravel's $route parameter is an array of properties */
-        foreach ($route[2] as $parameter) {
+        foreach ($route[2] ?? [] as $parameter) {
             if (($parameter instanceof RequestObjectInterface) === false) {
                 continue;
             }

--- a/src/Request/RequestBodyParamConverter.php
+++ b/src/Request/RequestBodyParamConverter.php
@@ -6,6 +6,7 @@ namespace LoyaltyCorp\RequestHandlers\Request;
 use Exception;
 use FOS\RestBundle\Context\Context;
 use FOS\RestBundle\Request\RequestBodyParamConverter as BaseRequestBodyParamConverter;
+use LoyaltyCorp\RequestHandlers\Exceptions\InvalidContentTypeException;
 use LoyaltyCorp\RequestHandlers\Serializer\PropertyNormalizer;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\Request;
@@ -39,6 +40,12 @@ final class RequestBodyParamConverter extends BaseRequestBodyParamConverter
     {
         $this->configuration = $configuration;
         $this->request = $request;
+
+        if ($request->getContentType() === null) {
+            throw new InvalidContentTypeException(
+                'Request has no content type when one is required for this Converter.'
+            );
+        }
 
         try {
             $result = parent::apply($request, $configuration);

--- a/src/Request/RequestBodyParamConverter.php
+++ b/src/Request/RequestBodyParamConverter.php
@@ -88,6 +88,8 @@ final class RequestBodyParamConverter extends BaseRequestBodyParamConverter
      */
     protected function configureContext(Context $context, array $options): void
     {
+        $context->setAttribute(PropertyNormalizer::DISABLE_TYPE_ENFORCEMENT, true);
+
         if ($this->request !== null && $this->configuration !== null) {
             $context->setAttribute(
                 PropertyNormalizer::EXTRA_PARAMETERS,

--- a/src/TestHelper/Exceptions/ValidationFailedException.php
+++ b/src/TestHelper/Exceptions/ValidationFailedException.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\TestHelper\Exceptions;
+
+use LoyaltyCorp\RequestHandlers\Exceptions\RequestValidationException;
+
+class ValidationFailedException extends RequestValidationException
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorCode(): int
+    {
+        return 42;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorSubCode(): int
+    {
+        return 1;
+    }
+}

--- a/src/TestHelper/RequestObjectTestHelper.php
+++ b/src/TestHelper/RequestObjectTestHelper.php
@@ -1,0 +1,188 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\TestHelper;
+
+use Illuminate\Contracts\Container\Container;
+use LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface;
+use LoyaltyCorp\RequestHandlers\Serializer\PropertyNormalizer;
+use LoyaltyCorp\RequestHandlers\TestHelper\Exceptions\ValidationFailedException;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * This test helper exists to have a single place where logic used by test cases
+ * can be centralised.
+ *
+ * It contains basic methods for creating validated and unvalidated request
+ * objects and extract properties from those request objects.
+ *
+ * This class should not be used by any normal services.
+ *
+ * @internal
+ */
+final class RequestObjectTestHelper
+{
+    /**
+     * @var \Illuminate\Contracts\Container\Container
+     */
+    private $app;
+
+    /**
+     * Constructor
+     *
+     * @param \Illuminate\Contracts\Container\Container $app
+     */
+    public function __construct(Container $app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * Builds a failing request and returns the validation errors raised by the failure.
+     *
+     * @param string $class
+     * @param string $json
+     * @param mixed[]|null $context
+     *
+     * @return mixed[]
+     */
+    public function buildFailingRequest(
+        string $class,
+        string $json,
+        ?array $context = null
+    ): array {
+        try {
+            $this->buildValidatedRequest($class, $json, $context);
+        } catch (ValidationFailedException $exception) {
+            return $exception->getErrors();
+        }
+
+        throw new \RuntimeException('There were no validation errors.');
+    }
+
+    /**
+     * Builds an unvalidated request object. The context property will set and overwrite
+     * any properties on the request object with the supplied values.
+     *
+     * @param string $class
+     * @param string $json
+     * @param mixed[]|null $context
+     *
+     * @return \LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface
+     */
+    public function buildUnvalidatedRequest(
+        string $class,
+        string $json,
+        ?array $context = null
+    ): RequestObjectInterface {
+        /** @var \Symfony\Component\Serializer\SerializerInterface $serializer */
+        $serializer = $this->app->get('requesthandlers_serializer');
+
+        /** @var \LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface $instance */
+        $instance = $serializer->deserialize(
+            $json,
+            $class,
+            'json',
+            [
+                PropertyNormalizer::EXTRA_PARAMETERS => $context ?? []
+            ]
+        );
+
+        return $instance;
+    }
+
+    /**
+     * Builds a validated request object. The context property will set and overwrite
+     * any properties on the request object with the supplied values.
+     *
+     * @param string $class
+     * @param string $json
+     * @param mixed[]|null $context
+     *
+     * @return \LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\TestHelper\Exceptions\ValidationFailedException
+     */
+    public function buildValidatedRequest(
+        string $class,
+        string $json,
+        ?array $context = null
+    ): RequestObjectInterface {
+        $instance = $this->buildUnvalidatedRequest($class, $json, $context);
+        $violations = $this->validateRequest($instance);
+
+        if ($violations->count() > 0) {
+            throw new ValidationFailedException($violations);
+        }
+
+        return $instance;
+    }
+
+    /**
+     * Returns an array of properties and their values when those properties have getters.
+     *
+     * @param \LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface $object
+     *
+     * @return mixed[]
+     */
+    public function getRequestProperties(RequestObjectInterface $object): array
+    {
+        $interfaceMethods = \get_class_methods(RequestObjectInterface::class);
+        $instanceMethods = \get_class_methods($object);
+
+        $methodsToCheck = \array_filter(
+            \array_diff($instanceMethods, $interfaceMethods),
+            static function (string $method): bool {
+                return \strncmp($method, 'get', 3) === 0;
+            }
+        );
+
+        $actual = [];
+        foreach ($methodsToCheck as $method) {
+            $property = \lcfirst(\substr($method, 3));
+
+            $callable = [$object, $method];
+            if (\is_callable($callable) === false) {
+                // @codeCoverageIgnoreStart
+                // Unable to be tested. get_class_methods returns only public methods
+                continue;
+                // @codeCoverageIgnoreEnd
+            }
+
+            $actual[$property] = $callable();
+        }
+
+        return $actual;
+    }
+
+    /**
+     * Validates a Dto
+     *
+     * @param \LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface $instance
+     *
+     * @return \Symfony\Component\Validator\ConstraintViolationList
+     */
+    private function validateRequest(RequestObjectInterface $instance): ConstraintViolationList
+    {
+        /** @var \Symfony\Component\Validator\Validator\ValidatorInterface $validator */
+        $validator = $this->app->get(ValidatorInterface::class);
+
+        // Pre-validate the object to match how the ValidatingMiddleware does it.
+
+        /** @var \Symfony\Component\Validator\ConstraintViolationList $violations */
+        $violations = $validator->validate($instance, null, ['PreValidate']);
+        if ($violations->count()) {
+            return $violations;
+        }
+
+        // Validate with default and resolved validation groups.
+        $groups = $instance->resolveValidationGroups();
+        $groups[] = 'Default';
+
+        /** @var \Symfony\Component\Validator\ConstraintViolationList $violations */
+        $violations = $validator->validate($instance, null, $groups);
+
+        return $violations;
+    }
+}

--- a/src/Validators/Filter.php
+++ b/src/Validators/Filter.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Validators;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Run a filter_var call on a property.
+ *
+ * @Annotation
+ *
+ * @Target({"METHOD", "PROPERTY"})
+ */
+final class Filter extends Constraint
+{
+    /**
+     * The FILTER_VALIDATE constant to be used.
+     *
+     * @var string
+     */
+    public $filter;
+
+    /**
+     * An array of FILTER_FLAG constants to be used.
+     *
+     * @var string[]|null
+     */
+    public $flags;
+
+    /**
+     * The error message to be presented.
+     *
+     * @var string
+     */
+    public $message = 'This value is not valid.';
+
+    /**
+     * @noinspection PhpMissingParentCallCommonInspection
+     *
+     * {@inheritdoc}
+     */
+    public function getDefaultOption(): string
+    {
+        return 'filter';
+    }
+
+    /**
+     * @noinspection PhpMissingParentCallCommonInspection
+     *
+     * {@inheritdoc}
+     */
+    public function getTargets(): string
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
+}

--- a/src/Validators/FilterValidator.php
+++ b/src/Validators/FilterValidator.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Validators;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+final class FilterValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint): void
+    {
+        if ($constraint instanceof Filter !== true) {
+            throw new UnexpectedTypeException($constraint, Filter::class);
+        }
+
+        if ($value === null || $value === '') {
+            // Dont validate empty values.
+
+            return;
+        }
+
+        /**
+         * @var \LoyaltyCorp\RequestHandlers\Validators\Filter $constraint
+         *
+         * @see https://youtrack.jetbrains.com/issue/WI-37859 - typehint required until PhpStorm recognises === check
+         */
+
+        $filter = \constant($constraint->filter);
+        $flags = 0;
+        foreach ($constraint->flags ?? [] as $flag) {
+            $flags |= \constant($flag) ?? 0;
+        }
+
+        $result = \filter_var($value, $filter, ['flags' => $flags]);
+
+        if ($result === false) {
+            $this->context->buildViolation($constraint->message)
+                ->setInvalidValue($value)
+                ->addViolation();
+        }
+    }
+}

--- a/tests/Exceptions/InvalidContentTypeExceptionTest.php
+++ b/tests/Exceptions/InvalidContentTypeExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Exceptions;
+
+use LoyaltyCorp\RequestHandlers\Exceptions\InvalidContentTypeException;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\RequestHandlers\Exceptions\InvalidContentTypeException
+ */
+class InvalidContentTypeExceptionTest extends TestCase
+{
+    /**
+     * Tests methods on InvalidContentTypeException
+     *
+     * @return void
+     */
+    public function testExceptionMethods(): void
+    {
+        $exception = new InvalidContentTypeException();
+
+        self::assertSame(1, $exception->getErrorSubCode());
+        self::assertSame(40, $exception->getErrorCode());
+        self::assertSame(500, $exception->getStatusCode());
+    }
+}

--- a/tests/Integration/Fixtures/Controller.php
+++ b/tests/Integration/Fixtures/Controller.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Integration\Fixtures;
+
+class Controller
+{
+    /**
+     * A basic controller method with no annotations.
+     *
+     * @return void
+     */
+    public function basicMethod(): void
+    {
+    }
+
+    /**
+     * A controller method with nothing for the RequestIntegration to do.
+     *
+     * @param string $baz
+     * @param \Tests\LoyaltyCorp\RequestHandlers\Integration\Fixtures\ThingRequest $request
+     *
+     * @return void
+     */
+    public function doThing(string $baz, ThingRequest $request): void
+    {
+    }
+}

--- a/tests/Integration/Fixtures/Controller.php
+++ b/tests/Integration/Fixtures/Controller.php
@@ -21,6 +21,8 @@ class Controller
      * @param \Tests\LoyaltyCorp\RequestHandlers\Integration\Fixtures\ThingRequest $request
      *
      * @return void
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function doThing(string $baz, ThingRequest $request): void
     {

--- a/tests/Integration/Fixtures/ThingRequest.php
+++ b/tests/Integration/Fixtures/ThingRequest.php
@@ -1,0 +1,174 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Integration\Fixtures;
+
+use EoneoPay\Utils\DateTime;
+use LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface;
+use LoyaltyCorp\RequestHandlers\Validators\Filter;
+use Symfony\Component\Validator\Constraints as Assert;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Exceptions\RequestValidationExceptionStub;
+
+class ThingRequest implements RequestObjectInterface
+{
+    /**
+     * A not nullable string amount.
+     *
+     * @Assert\NotNull()
+     * @Assert\GreaterThan(1)
+     * @Assert\Type("numeric")
+     *
+     * @var string|float|int
+     */
+    private $amount;
+
+    /**
+     * Property for importing via route attributes.
+     *
+     * @Assert\Type("string")
+     *
+     * @var string
+     */
+    private $baz;
+
+    /**
+     * Not nullable string date
+     *
+     * @Assert\NotNull()
+     * @Assert\DateTime(format="Y-m-d\TH:i:sP")
+     * @Assert\Type("string")
+     *
+     * @var string
+     */
+    private $date;
+
+    /**
+     * Float
+     *
+     * @Assert\NotNull
+     * @Assert\GreaterThan(0.5)
+     * @Assert\Type("numeric")
+     *
+     * @var float|int|string
+     */
+    private $float;
+
+    /**
+     * Integer
+     *
+     * @Assert\LessThan(0)
+     * @Assert\NotNull()
+     *
+     * @Filter("FILTER_VALIDATE_INT")
+     *
+     * @var int|string
+     */
+    private $int;
+
+    /**
+     * A not nullable string
+     *
+     * @Assert\Length(min=2)
+     * @Assert\NotNull()
+     * @Assert\Type("string")
+     *
+     * @var string
+     */
+    private $string;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getExceptionClass(): string
+    {
+        return RequestValidationExceptionStub::class;
+    }
+
+    /**
+     * Returns amount
+     *
+     * @return string
+     */
+    public function getAmount(): string
+    {
+        return (string)$this->amount;
+    }
+
+    /**
+     * Returns the baz
+     *
+     * @return string
+     */
+    public function getBaz(): string
+    {
+        return $this->baz;
+    }
+
+    /**
+     * Returns date
+     *
+     * @return \EoneoPay\Utils\DateTime
+     *
+     * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
+     */
+    public function getDate(): DateTime
+    {
+        return new DateTime($this->date);
+    }
+
+    /**
+     * Returns float
+     *
+     * @return float
+     */
+    public function getFloat(): float
+    {
+        return (float)$this->float;
+    }
+
+    /**
+     * Returns int
+     *
+     * @return int
+     */
+    public function getInt(): int
+    {
+        return (int)$this->int;
+    }
+
+    /**
+     * Returns string
+     *
+     * @return string
+     */
+    public function getString(): string
+    {
+        return $this->string;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolveValidationGroups(): array
+    {
+        return [];
+    }
+
+    /**
+     * Array used for testing assertions.
+     *
+     * @return mixed[]
+     *
+     * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
+     */
+    public function toArray(): array
+    {
+        return [
+            'amount' => $this->getAmount(),
+            'date' => $this->getDate(),
+            'float' => $this->getFloat(),
+            'int' => $this->getInt(),
+            'string' => $this->getString()
+        ];
+    }
+}

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -1,0 +1,482 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Integration;
+
+use DateTime as BaseDateTime;
+use DateTimeZone;
+use EoneoPay\Utils\AnnotationReader;
+use EoneoPay\Utils\Bridge\Lumen\Resolvers\ControllerResolver;
+use EoneoPay\Utils\DateTime;
+use FOS\RestBundle\Serializer\SymfonySerializerAdapter;
+use Illuminate\Http\Request;
+use Illuminate\Pipeline\Pipeline;
+use LoyaltyCorp\RequestHandlers\Middleware\ParamConverterMiddleware;
+use LoyaltyCorp\RequestHandlers\Middleware\ValidatingMiddleware;
+use LoyaltyCorp\RequestHandlers\Request\RequestBodyParamConverter;
+use LoyaltyCorp\RequestHandlers\Serializer\PropertyNormalizer;
+use LoyaltyCorp\RequestHandlers\Serializer\RequestBodySerializer;
+use Sensio\Bundle\FrameworkExtraBundle\EventListener\ControllerListener;
+use Sensio\Bundle\FrameworkExtraBundle\EventListener\ParamConverterListener;
+use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterManager;
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\DateIntervalNormalizer;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Validator\ConstraintValidatorFactory;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Tests\LoyaltyCorp\RequestHandlers\Integration\Fixtures\Controller;
+use Tests\LoyaltyCorp\RequestHandlers\Integration\Fixtures\ThingRequest;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Exceptions\RequestValidationExceptionStub;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Illuminate\Contracts\Foundation\ApplicationStub;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+/**
+ * Tests all services defined and required by this package as a single unit
+ * to ensure that the expected behaviour is correct.
+ */
+class RequestIntegrationTest extends TestCase
+{
+    /**
+     * Returns data for testSuccess
+     *
+     * @return string[]
+     *
+     * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
+     */
+    public function getSuccessData(): iterable
+    {
+        $json = <<<JSON
+{
+  "amount": "10.00",
+  "date": "2019-01-02T03:04:05Z",
+  "float": 0.75,
+  "int": -10,
+  "string": "string"
+}
+JSON;
+
+        yield 'json' => [
+            'content' => $json,
+            'contentType' => 'application/json',
+            'expectedResult' => [
+                'amount' => '10.00',
+                'date' => new DateTime('2019-01-02T03:04:05Z'),
+                'float' => 0.75,
+                'int' => -10,
+                'string' => 'string'
+            ]
+        ];
+
+        $json = <<<JSON
+{
+  "amount": "10.00",
+  "date": "2019-01-02T03:04:05Z",
+  "float": "0.75",
+  "int": -10,
+  "string": "string"
+}
+JSON;
+
+        yield 'json with strings' => [
+            'content' => $json,
+            'contentType' => 'application/json',
+            'expectedResult' => [
+                'amount' => '10.00',
+                'date' => new DateTime('2019-01-02T03:04:05Z'),
+                'float' => 0.75,
+                'int' => -10,
+                'string' => 'string'
+            ]
+        ];
+
+        $json = <<<JSON
+{
+  "amount": 10,
+  "date": "2019-01-02T03:04:05Z",
+  "float": 0.75,
+  "int": -10,
+  "string": "string"
+}
+JSON;
+
+        yield 'json with ints' => [
+            'content' => $json,
+            'contentType' => 'application/json',
+            'expectedResult' => [
+                'amount' => '10',
+                'date' => new DateTime('2019-01-02T03:04:05Z'),
+                'float' => 0.75,
+                'int' => -10,
+                'string' => 'string'
+            ]
+        ];
+
+        $json = <<<JSON
+{
+  "amount": 10.00,
+  "date": "2019-01-02T03:04:05Z",
+  "float": 0.75,
+  "int": -10,
+  "string": "string"
+}
+JSON;
+
+        yield 'json with floats' => [
+            'content' => $json,
+            'contentType' => 'application/json',
+            'expectedResult' => [
+                'amount' => '10',
+                'date' => new DateTime('2019-01-02T03:04:05Z'),
+                'float' => 0.75,
+                'int' => -10,
+                'string' => 'string'
+            ]
+        ];
+
+        $xml = <<<XML
+<?xml version="1.0"?>
+<document>
+  <amount>10.00</amount>
+  <date>2019-01-02T03:04:05Z</date>
+  <float>0.75</float>
+  <int>-10</int>
+  <string>string</string>
+</document>
+XML;
+
+        yield 'xml' => [
+            'content' => $xml,
+            'contentType' => 'text/xml',
+            'expectedResult' => [
+                'amount' => '10.00',
+                'date' => new DateTime('2019-01-02T03:04:05Z'),
+                'float' => 0.75,
+                'int' => -10,
+                'string' => 'string'
+            ]
+        ];
+
+        $xml = <<<XML
+<?xml version="1.0"?>
+<document>
+  <amount>10</amount>
+  <date>2019-01-02T03:04:05Z</date>
+  <float>0.75</float>
+  <int>-10</int>
+  <string>string</string>
+</document>
+XML;
+
+        yield 'xml with int amount for string' => [
+            'content' => $xml,
+            'contentType' => 'text/xml',
+            'expectedResult' => [
+                'amount' => '10',
+                'date' => new DateTime('2019-01-02T03:04:05Z'),
+                'float' => 0.75,
+                'int' => -10,
+                'string' => 'string'
+            ]
+        ];
+
+        $xml = <<<XML
+<?xml version="1.0"?>
+<document>
+  <amount><![CDATA[10.00]]></amount>
+  <date><![CDATA[2019-01-02T03:04:05Z]]></date>
+  <float><![CDATA[0.75]]></float>
+  <int><![CDATA[-10]]></int>
+  <string><![CDATA[string]]></string>
+</document>
+XML;
+
+        yield 'xml with cdata' => [
+            'content' => $xml,
+            'contentType' => 'text/xml',
+            'expectedResult' => [
+                'amount' => '10.00',
+                'date' => new DateTime('2019-01-02T03:04:05Z'),
+                'float' => 0.75,
+                'int' => -10,
+                'string' => 'string'
+            ]
+        ];
+    }
+
+    /**
+     * Tests the process when the request is empty.
+     *
+     * @return void
+     *
+     * @throws \EoneoPay\Utils\Exceptions\AnnotationCacheException
+     */
+    public function testEmptyRequest(): void
+    {
+        $request = $this->buildRequest(Controller::class, 'basicMethod');
+
+        $pipeline = $this->buildPipeline($request);
+
+        $pipeline->thenReturn();
+
+        // Asserting that no exceptions occurred.
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * Test successful request with json.
+     *
+     * @param string $content
+     * @param string $contentType
+     * @param mixed[] $expectedResult
+     *
+     * @return void
+     *
+     * @throws \EoneoPay\Utils\Exceptions\AnnotationCacheException
+     * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
+     *
+     * @dataProvider getSuccessData
+     */
+    public function testSuccess(string $content, string $contentType, array $expectedResult): void
+    {
+        $request = $this->buildRequest(
+            Controller::class,
+            'doThing',
+            $content,
+            $contentType,
+            ['baz' => 'flub']
+        );
+
+        $pipeline = $this->buildPipeline($request);
+
+        $pipeline->thenReturn();
+
+        // Assert that the middleware added additional route attributes into the attribute bag
+        static::assertSame('flub', $request->attributes->get('baz'));
+
+        $thing = $request->attributes->get('request');
+
+        // Assert that ThingRequest got built by the param converter
+        static::assertInstanceOf(ThingRequest::class, $thing);
+
+        /**
+         * @var \Tests\LoyaltyCorp\RequestHandlers\Integration\Fixtures\ThingRequest $thing
+         */
+
+        static::assertSame('flub', $thing->getBaz());
+        static::assertEquals($expectedResult, $thing->toArray());
+
+        // Assert that the Middleware put $thing into the laravel route
+        static::assertSame($thing, $request->route()[2]['request']);
+    }
+
+    /**
+     * Test validation failure.
+     *
+     * @return void
+     *
+     * @throws \EoneoPay\Utils\Exceptions\AnnotationCacheException
+     */
+    public function testValidationFailure(): void
+    {
+        $json = <<<JSON
+{}
+JSON;
+
+        // Expected violations from ThingRequest as a debug string output.
+        $expectedViolations = <<<VIOLATIONS
+Object(Tests\LoyaltyCorp\RequestHandlers\Integration\Fixtures\ThingRequest).amount:
+    This value should not be null. (code ad32d13f-c3d4-423b-909a-857b961eb720)
+Object(Tests\LoyaltyCorp\RequestHandlers\Integration\Fixtures\ThingRequest).date:
+    This value should not be null. (code ad32d13f-c3d4-423b-909a-857b961eb720)
+Object(Tests\LoyaltyCorp\RequestHandlers\Integration\Fixtures\ThingRequest).float:
+    This value should not be null. (code ad32d13f-c3d4-423b-909a-857b961eb720)
+Object(Tests\LoyaltyCorp\RequestHandlers\Integration\Fixtures\ThingRequest).int:
+    This value should not be null. (code ad32d13f-c3d4-423b-909a-857b961eb720)
+Object(Tests\LoyaltyCorp\RequestHandlers\Integration\Fixtures\ThingRequest).string:
+    This value should not be null. (code ad32d13f-c3d4-423b-909a-857b961eb720)
+
+VIOLATIONS;
+
+        $request = $this->buildRequest(Controller::class, 'doThing', $json);
+
+        $pipeline = $this->buildPipeline($request);
+
+        try {
+            $pipeline->thenReturn();
+        } catch (RequestValidationExceptionStub $exception) {
+            /** @var \Symfony\Component\Validator\ConstraintViolationList $violations */
+            $violations = $exception->getViolations();
+
+            static::assertSame($expectedViolations, (string)$violations);
+
+            return;
+        }
+
+        static::fail('Exception not thrown');
+    }
+
+    /**
+     * Builds the ParamConverterManager
+     *
+     * @param \Symfony\Component\Serializer\SerializerInterface $serializer
+     *
+     * @return \Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterManager
+     */
+    private function buildParamConverters(SerializerInterface $serializer): ParamConverterManager
+    {
+        $requestBody = new RequestBodyParamConverter(
+            new SymfonySerializerAdapter($serializer)
+        );
+
+        $manager = new ParamConverterManager();
+        $manager->add($requestBody);
+
+        return $manager;
+    }
+
+    /**
+     * Builds the full chain of dependencies.
+     *
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return \Illuminate\Pipeline\Pipeline
+     *
+     * @throws \EoneoPay\Utils\Exceptions\AnnotationCacheException
+     */
+    private function buildPipeline(Request $request): Pipeline
+    {
+        $annotationReader = new AnnotationReader();
+        $container = new ApplicationStub();
+
+        $serializer = $this->buildSerializer($annotationReader);
+        $validator = $this->buildValidator($annotationReader);
+        $paramConverters = $this->buildParamConverters($serializer);
+
+        $controllerListener = new ControllerListener($annotationReader);
+        $controllerResolver = new ControllerResolver($container);
+        $converterListener = new ParamConverterListener($paramConverters);
+
+        $pcm = new ParamConverterMiddleware(
+            $controllerListener,
+            $controllerResolver,
+            $converterListener
+        );
+
+        $validatingMiddleware = new ValidatingMiddleware($validator);
+
+        $pipeline = new Pipeline(null);
+        $pipeline->send($request);
+        $pipeline->through([$pcm, $validatingMiddleware]);
+
+        return $pipeline;
+    }
+
+    /**
+     * Builds a request object.
+     *
+     * @param string $controller
+     * @param string $method
+     * @param null|string $content
+     * @param null|string $contentType
+     * @param mixed[]|null $routeAttributes
+     *
+     * @return \Illuminate\Http\Request
+     */
+    private function buildRequest(
+        string $controller,
+        string $method,
+        ?string $content = null,
+        ?string $contentType = null,
+        ?array $routeAttributes = null
+    ): Request {
+        $request = new Request();
+        $request->initialize([], [], [], [], [], [
+            'HTTP_CONTENT_TYPE' => $contentType ?? 'application/json'
+        ], $content);
+        $request->setRouteResolver(
+            static function () use ($controller, $method, $routeAttributes) {
+                return [
+                    1 => ['uses' => \sprintf('%s@%s', $controller, $method)],
+                    2 => $routeAttributes ?? []
+                ];
+            }
+        );
+
+        return $request;
+    }
+
+    /**
+     * Builds the serializer under test.
+     *
+     * @param \EoneoPay\Utils\AnnotationReader $reader
+     *
+     * @return \LoyaltyCorp\RequestHandlers\Serializer\RequestBodySerializer
+     */
+    private function buildSerializer(AnnotationReader $reader): RequestBodySerializer
+    {
+        $metadataFactory = new ClassMetadataFactory(new AnnotationLoader($reader));
+
+        $reflectionExtractor = new ReflectionExtractor();
+        $phpDocExtractor = new PhpDocExtractor();
+
+        $normalizers = [
+            new ArrayDenormalizer(),
+            new DateIntervalNormalizer(
+                [
+                    DateIntervalNormalizer::FORMAT_KEY => 'P%mM'
+                ]
+            ),
+            new DateTimeNormalizer(
+                [
+                    DateTimeNormalizer::FORMAT_KEY => BaseDateTime::RFC3339
+                ],
+                new DateTimeZone('UTC')
+            ),
+            new PropertyNormalizer(
+                $metadataFactory,
+                new CamelCaseToSnakeCaseNameConverter(),
+                new PropertyInfoExtractor(
+                    [$reflectionExtractor],
+                    [$phpDocExtractor],
+                    [$phpDocExtractor],
+                    [$reflectionExtractor],
+                    [$reflectionExtractor]
+                )
+            )
+        ];
+
+        $encoders = [
+            new JsonEncoder(),
+            new XmlEncoder()
+        ];
+
+        return new RequestBodySerializer($normalizers, $encoders);
+    }
+
+    /**
+     * Builds the validator under test.
+     *
+     * @param \EoneoPay\Utils\AnnotationReader $reader
+     *
+     * @return \Symfony\Component\Validator\Validator\ValidatorInterface
+     */
+    private function buildValidator(AnnotationReader $reader): ValidatorInterface
+    {
+        $constraintFactory = new ConstraintValidatorFactory();
+
+        return Validation::createValidatorBuilder()
+            ->enableAnnotationMapping($reader)
+            ->setConstraintValidatorFactory($constraintFactory)
+            ->getValidator();
+    }
+}

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -43,6 +43,8 @@ use Tests\LoyaltyCorp\RequestHandlers\TestCase;
 /**
  * Tests all services defined and required by this package as a single unit
  * to ensure that the expected behaviour is correct.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class RequestIntegrationTest extends TestCase
 {
@@ -52,6 +54,8 @@ class RequestIntegrationTest extends TestCase
      * @return string[]
      *
      * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function getSuccessData(): iterable
     {

--- a/tests/Middleware/ParamConverterMiddlewareTest.php
+++ b/tests/Middleware/ParamConverterMiddlewareTest.php
@@ -68,6 +68,51 @@ class ParamConverterMiddlewareTest extends TestCase
     }
 
     /**
+     * Tests handle route with no parameters
+     *
+     * @return void
+     */
+    public function testHandleRouteNoParams(): void
+    {
+        $container = new Container();
+        $container->instance('Class', new class
+        {
+            /**
+             * Method for test
+             *
+             * @return void
+             */
+            public function method(): void
+            {
+            }
+        });
+        $controllerListener = $this->createMock(ControllerListener::class);
+        $paramListener = $this->createMock(ParamConverterListener::class);
+
+        $middleware = new ParamConverterMiddleware(
+            $controllerListener,
+            new ControllerResolver($container),
+            $paramListener
+        );
+
+        $request = new Request();
+        $request->setRouteResolver(static function () {
+            return [
+                null,
+                ['uses' => 'Class@method']
+            ];
+        });
+        $next = static function () {
+            return 'hello';
+        };
+
+        $result = $middleware->handle($request, $next);
+
+        // No fatal error occurred
+        static::assertSame('hello', $result);
+    }
+
+    /**
      * Tests handle with bad route
      *
      * @return void

--- a/tests/Middleware/ValidatingMiddlewareTest.php
+++ b/tests/Middleware/ValidatingMiddlewareTest.php
@@ -84,6 +84,33 @@ class ValidatingMiddlewareTest extends TestCase
     }
 
     /**
+     * Tests middleware handle method when there are no parameters
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\RequestValidationException
+     */
+    public function testHandleMissingParams(): void
+    {
+        $validator = new ValidatorStub();
+
+        $middleware = new ValidatingMiddleware($validator);
+
+        $request = new Request();
+        $request->setRouteResolver(static function () {
+            return [null, null];
+        });
+
+        $next = static function () {
+            return 'hello';
+        };
+
+        $result = $middleware->handle($request, $next);
+
+        self::assertSame('hello', $result);
+    }
+
+    /**
      * Tests middleware handle method when there is no route
      *
      * @return void

--- a/tests/Request/RequestBodyParamConverterTest.php
+++ b/tests/Request/RequestBodyParamConverterTest.php
@@ -78,11 +78,7 @@ class RequestBodyParamConverterTest extends TestCase
     {
         $this->expectException(InvalidContentTypeException::class);
 
-        $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->expects(self::once())
-            ->method('deserialize')
-            ->willThrowException(new RuntimeException());
-
+        $serializer = new SerializerStub(new RuntimeException());
         $converter = new RequestBodyParamConverter(new SymfonySerializerAdapter($serializer));
 
         $request = new Request();

--- a/tests/Stubs/Vendor/Doctrine/Common/Persistence/ManagerRegistryStub.php
+++ b/tests/Stubs/Vendor/Doctrine/Common/Persistence/ManagerRegistryStub.php
@@ -66,8 +66,9 @@ class ManagerRegistryStub implements ManagerRegistry
     /**
      * {@inheritdoc}
      */
-    public function getManagerNames()
+    public function getManagerNames(): array
     {
+        return [];
     }
 
     /**

--- a/tests/Stubs/Vendor/Symfony/Translator/TranslatorStub.php
+++ b/tests/Stubs/Vendor/Symfony/Translator/TranslatorStub.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Symfony\Translator;
+
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * @coversNothing
+ *
+ * @SuppressWarnings(PHPMD.ShortVariable) From interface docs
+ */
+class TranslatorStub implements TranslatorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function trans(
+        $id,
+        ?array $parameters = null,
+        $domain = null,
+        $locale = null
+    ): string {
+        return $id;
+    }
+}

--- a/tests/TestHelper/Exceptions/ValidationFailedExceptionTest.php
+++ b/tests/TestHelper/Exceptions/ValidationFailedExceptionTest.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\TestHelper\Exceptions;
+
+use LoyaltyCorp\RequestHandlers\TestHelper\Exceptions\ValidationFailedException;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\RequestHandlers\TestHelper\Exceptions\ValidationFailedException
+ */
+class ValidationFailedExceptionTest extends TestCase
+{
+    /**
+     * Tests methods on DoctrineDenormalizerMappingException
+     *
+     * @return void
+     */
+    public function testExceptionMethods(): void
+    {
+        $violations = new ConstraintViolationList();
+        $exception = new ValidationFailedException($violations);
+
+        self::assertSame(1, $exception->getErrorSubCode());
+        self::assertSame(42, $exception->getErrorCode());
+        self::assertSame(400, $exception->getStatusCode());
+        self::assertSame($violations, $exception->getViolations());
+    }
+}

--- a/tests/TestHelper/Fixtures/TestRequest.php
+++ b/tests/TestHelper/Fixtures/TestRequest.php
@@ -30,7 +30,7 @@ class TestRequest implements RequestObjectInterface
      *
      * @return mixed
      */
-    public function getProperty(): ?string
+    public function getProperty()
     {
         return $this->property;
     }

--- a/tests/TestHelper/Fixtures/TestRequest.php
+++ b/tests/TestHelper/Fixtures/TestRequest.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\TestHelper\Fixtures;
+
+use LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class TestRequest implements RequestObjectInterface
+{
+    /**
+     * @Assert\Type("string")
+     *
+     * @var mixed
+     */
+    private $property;
+
+    /**
+     * Constructor
+     *
+     * @param mixed $property
+     */
+    public function __construct($property = null)
+    {
+        $this->property = $property;
+    }
+
+    /**
+     * Returns the property
+     *
+     * @return mixed
+     */
+    public function getProperty(): ?string
+    {
+        return $this->property;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getExceptionClass(): string
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolveValidationGroups(): array
+    {
+        return [];
+    }
+}

--- a/tests/TestHelper/RequestObjectTestHelperTest.php
+++ b/tests/TestHelper/RequestObjectTestHelperTest.php
@@ -136,7 +136,7 @@ class RequestObjectTestHelperTest extends TestCase
      * Gets helper under test.
      *
      * @param \Throwable|object $object
-     * @param \Symfony\Component\Validator\ConstraintViolationInterface[][]|null $violations
+     * @param \Symfony\Component\Validator\ConstraintViolation[][]|null $violations
      *
      * @return \LoyaltyCorp\RequestHandlers\TestHelper\RequestObjectTestHelper
      */

--- a/tests/TestHelper/RequestObjectTestHelperTest.php
+++ b/tests/TestHelper/RequestObjectTestHelperTest.php
@@ -1,0 +1,155 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\TestHelper;
+
+use LoyaltyCorp\RequestHandlers\TestHelper\Exceptions\ValidationFailedException;
+use LoyaltyCorp\RequestHandlers\TestHelper\RequestObjectTestHelper;
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Illuminate\Contracts\Foundation\ApplicationStub;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Symfony\SerializerStub;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Symfony\Validator\ValidatorStub;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+use Tests\LoyaltyCorp\RequestHandlers\TestHelper\Fixtures\TestRequest;
+
+/**
+ * @covers \LoyaltyCorp\RequestHandlers\TestHelper\RequestObjectTestHelper
+ */
+class RequestObjectTestHelperTest extends TestCase
+{
+    /**
+     * Tests buildFailedRequest
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\TestHelper\Exceptions\ValidationFailedException
+     */
+    public function testBuildFailedRequest(): void
+    {
+        $object = new TestRequest();
+        $expected = [
+            'property' => ['Message']
+        ];
+
+        $helper = $this->getHelper($object, [[
+            new ConstraintViolation('Message', '', [], '', 'property', '')
+        ]]);
+
+        $result = $helper->buildFailingRequest(TestRequest::class, '');
+
+        static::assertSame($expected, $result);
+    }
+
+    /**
+     * Tests buildFailedRequest
+     *
+     * @return void
+     */
+    public function testBuildFailedRequestNotFailing(): void
+    {
+        $object = new TestRequest();
+
+        $helper = $this->getHelper($object, [[]]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('There were no validation errors.');
+
+        $helper->buildFailingRequest(TestRequest::class, '');
+    }
+
+    /**
+     * Tests unvalidated request creation
+     *
+     * @return void
+     */
+    public function testGetRequestProperties(): void
+    {
+        $object = new TestRequest('test');
+        $expected = [
+            'property' => 'test'
+        ];
+
+        $helper = $this->getHelper($object);
+
+        $properties = $helper->getRequestProperties($object);
+
+        static::assertSame($expected, $properties);
+    }
+
+    /**
+     * Tests unvalidated request creation
+     *
+     * @return void
+     */
+    public function testUnvalidatedRequest(): void
+    {
+        $object = new TestRequest();
+
+        $helper = $this->getHelper($object);
+
+        $thing = $helper->buildUnvalidatedRequest(TestRequest::class, '');
+
+        static::assertSame($object, $thing);
+    }
+
+    /**
+     * Tests validated request creation
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\TestHelper\Exceptions\ValidationFailedException
+     */
+    public function testValidatedRequest(): void
+    {
+        $object = new TestRequest();
+
+        $helper = $this->getHelper($object, [[]]);
+
+        $thing = $helper->buildValidatedRequest(TestRequest::class, '');
+
+        static::assertSame($object, $thing);
+    }
+
+    /**
+     * Tests validated request creation when theres a validation failure
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\TestHelper\Exceptions\ValidationFailedException
+     */
+    public function testValidatedRequestWhenUnvalidated(): void
+    {
+        $object = new TestRequest();
+
+        $helper = $this->getHelper($object, [[
+            new ConstraintViolation('', '', [], '', '', '')
+        ]]);
+
+        $this->expectException(ValidationFailedException::class);
+
+        $helper->buildValidatedRequest(TestRequest::class, '');
+    }
+
+    /**
+     * Gets helper under test.
+     *
+     * @param \Throwable|object $object
+     * @param \Symfony\Component\Validator\ConstraintViolationInterface[][]|null $violations
+     *
+     * @return \LoyaltyCorp\RequestHandlers\TestHelper\RequestObjectTestHelper
+     */
+    private function getHelper($object = null, ?array $violations = null): RequestObjectTestHelper
+    {
+        $container = new ApplicationStub();
+
+        $serializer = new SerializerStub($object);
+        $container->instance('requesthandlers_serializer', $serializer);
+
+        $validator = new ValidatorStub($violations);
+        $container->instance(ValidatorInterface::class, $validator);
+
+        return new RequestObjectTestHelper($container);
+    }
+}

--- a/tests/Validators/FilterTest.php
+++ b/tests/Validators/FilterTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Validators;
+
+use LoyaltyCorp\RequestHandlers\Validators\Filter;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\RequestHandlers\Validators\Filter
+ */
+class FilterTest extends TestCase
+{
+    /**
+     * Test that the annotation targets classes
+     *
+     * @return void
+     */
+    public function testTarget(): void
+    {
+        $classConstant = 'property';
+        $constraint = new Filter();
+
+        self::assertSame($classConstant, $constraint->getTargets());
+    }
+}

--- a/tests/Validators/FilterValidatorTest.php
+++ b/tests/Validators/FilterValidatorTest.php
@@ -1,0 +1,167 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Validators;
+
+use LoyaltyCorp\RequestHandlers\Validators\Filter;
+use LoyaltyCorp\RequestHandlers\Validators\FilterValidator;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\Context\ExecutionContext;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Symfony\Translator\TranslatorStub;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Symfony\Validator\ValidatorStub;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\RequestHandlers\Validators\FilterValidator
+ */
+class FilterValidatorTest extends TestCase
+{
+    /**
+     * Test invalid constraint passed
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function testInvalidConstraint(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+        $this->expectExceptionMessage('Expected argument of type "LoyaltyCorp\RequestHandlers\Validators\Filter", "Symfony\Component\Validator\Constraints\NotBlank" given'); // phpcs:ignore
+
+        $validator = $this->getValidatorInstance();
+        $validator->validate(null, new NotBlank());
+    }
+
+    /**
+     * Test bails on empty value
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function testEmptyValue(): void
+    {
+        $constraint = new Filter();
+
+        $validator = $this->getValidatorInstance();
+        $context = $this->buildContext($constraint);
+        $validator->initialize($context);
+
+        $validator->validate(null, $constraint);
+
+        static::assertCount(0, $context->getViolations());
+    }
+
+    /**
+     * Test filter int
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function testFilterInt(): void
+    {
+        $constraint = new Filter(['filter' => 'FILTER_VALIDATE_INT']);
+
+        $validator = $this->getValidatorInstance();
+        $context = $this->buildContext($constraint);
+        $validator->initialize($context);
+
+        $validator->validate(5, $constraint);
+
+        static::assertCount(0, $context->getViolations());
+    }
+
+    /**
+     * Test filter int when it isnt
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function testFilterStringInt(): void
+    {
+        $constraint = new Filter(['filter' => 'FILTER_VALIDATE_INT']);
+
+        $validator = $this->getValidatorInstance();
+        $context = $this->buildContext($constraint);
+        $validator->initialize($context);
+
+        $validator->validate('purple', $constraint);
+
+        $violation = new ConstraintViolation(
+            'This value is not valid.',
+            'This value is not valid.',
+            [],
+            'root',
+            '',
+            'purple',
+            null,
+            null,
+            $constraint
+        );
+
+        static::assertCount(1, $context->getViolations());
+        static::assertEquals($violation, $context->getViolations()[0]);
+    }
+
+    /**
+     * Test filter int when it isnt
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function testFilterHexIntFlags(): void
+    {
+        $constraint = new Filter([
+            'filter' => 'FILTER_VALIDATE_INT',
+            'flags' => ['FILTER_FLAG_ALLOW_HEX']
+        ]);
+
+        $validator = $this->getValidatorInstance();
+        $context = $this->buildContext($constraint);
+        $validator->initialize($context);
+
+        $validator->validate('0x5a', $constraint);
+
+        static::assertCount(0, $context->getViolations());
+    }
+
+    /**
+     * Builds a fake ExecutionContext
+     *
+     * @param \Symfony\Component\Validator\Constraint $constraint
+     *
+     * @return \Symfony\Component\Validator\Context\ExecutionContextInterface
+     */
+    private function buildContext(Constraint $constraint): ExecutionContextInterface
+    {
+        $validator = new ValidatorStub();
+        $translator = new TranslatorStub();
+
+        $context = new ExecutionContext(
+            $validator,
+            'root',
+            $translator
+        );
+
+        $context->setConstraint($constraint);
+
+        return $context;
+    }
+
+    /**
+     * Get endpoint token validator instance
+     *
+     * @return \LoyaltyCorp\RequestHandlers\Validators\FilterValidator
+     */
+    private function getValidatorInstance(): FilterValidator
+    {
+        return new FilterValidator();
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 /**
  * @coversNothing
  */
+
+use Doctrine\Common\Annotations\AnnotationRegistry;
+
 if (\function_exists('xdebug_set_filter') === false) {
     return;
 }
@@ -15,3 +18,8 @@ if (\function_exists('xdebug_set_filter') === false) {
     \XDEBUG_PATH_WHITELIST,
     [\sprintf('%s/src', \dirname(__DIR__))]
 );
+
+require_once __DIR__.'/../vendor/autoload.php';
+
+// Until Doctrine Annotations v2.0, we need to register an autoloader, which is just 'class_exists'.
+AnnotationRegistry::registerUniqueLoader('class_exists');


### PR DESCRIPTION
- Strengthens the middleware in the case of bad requests/routes
- Handles requests without content type set
- Disables serialiser type enforcement
- Enables annotation reader for tests
- Add new @Filter validation constraint
- Adds a full integration test