### PR TITLE
Overwrite Sensio ParamConverterListener behaviour

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -53,3 +53,15 @@ parameters:
         -
             message: '#Call to static method PHPUnit\\Framework\\Assert::assertSame\(\) with .purple. and object will always evaluate to false\.#'
             path: tests/Serializer/DoctrineDenormalizerTest.php
+        -
+            message: '#Result of && is always false\.#'
+            path: src/EventListeners/ParamConverterListener.php
+        -
+            message: '#Strict comparison using === between string and null will always evaluate to false\.#'
+            path: src/EventListeners/ParamConverterListener.php
+        -
+            message: '#Strict comparison using !== between string and null will always evaluate to true\.#'
+            path: src/Request/ParamConverterManager.php
+        -
+            message: '#Call to static method PHPUnit\\Framework\\Assert::assertNull\(\) with string will always evaluate to false\.#'
+            path: tests/EventListeners/ParamConverterListenerTest.php

--- a/src/Bridge/Laravel/Providers/ParamConverterProvider.php
+++ b/src/Bridge/Laravel/Providers/ParamConverterProvider.php
@@ -11,15 +11,16 @@ use EoneoPay\Utils\AnnotationReader;
 use FOS\RestBundle\Serializer\SymfonySerializerAdapter;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\ServiceProvider;
+use LoyaltyCorp\RequestHandlers\EventListeners\ParamConverterListener;
 use LoyaltyCorp\RequestHandlers\Request\DoctrineParamConverter;
+use LoyaltyCorp\RequestHandlers\Request\Interfaces\ParamConverterManagerInterface;
+use LoyaltyCorp\RequestHandlers\Request\ParamConverterManager;
 use LoyaltyCorp\RequestHandlers\Request\RequestBodyParamConverter;
 use LoyaltyCorp\RequestHandlers\Serializer\DoctrineDenormalizer;
 use LoyaltyCorp\RequestHandlers\Serializer\PropertyNormalizer;
 use LoyaltyCorp\RequestHandlers\Serializer\RequestBodySerializer;
 use Sensio\Bundle\FrameworkExtraBundle\EventListener\ControllerListener;
-use Sensio\Bundle\FrameworkExtraBundle\EventListener\ParamConverterListener;
 use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\DoctrineParamConverter as RealDoctrineParamConverter;
-use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterManager;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -117,15 +118,13 @@ final class ParamConverterProvider extends ServiceProvider
                 );
             }
         );
-        $this->app->singleton(ParamConverterListener::class, static function (Container $app): ParamConverterListener {
-            return new ParamConverterListener($app->make(ParamConverterManager::class), false);
-        });
+        $this->app->singleton(ParamConverterListener::class);
         $this->app->singleton(
-            ParamConverterManager::class,
+            ParamConverterManagerInterface::class,
             static function (Container $app): ParamConverterManager {
                 $manager = new ParamConverterManager();
-                $manager->add($app->make(RealDoctrineParamConverter::class), 5);
-                $manager->add($app->make(RequestBodyParamConverter::class), 1);
+                $manager->add($app->make(RealDoctrineParamConverter::class), 5, null);
+                $manager->add($app->make(RequestBodyParamConverter::class), 1, null);
 
                 return $manager;
             }

--- a/src/EventListeners/ParamConverterListener.php
+++ b/src/EventListeners/ParamConverterListener.php
@@ -1,0 +1,181 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\EventListeners;
+
+use LoyaltyCorp\RequestHandlers\Exceptions\InvalidRequestAttributeException;
+use LoyaltyCorp\RequestHandlers\Request\Interfaces\ParamConverterManagerInterface;
+use ReflectionFunctionAbstract;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * A custom ParamConverterListener that implements similar functionality to the
+ * SensioFrameworkExtra bundle, but customised for our requirements.
+ *
+ * Specifically, the differences are:
+ * - Use a custom ParamConverterManager that has an interface
+ * - Do not support autoconfiguration, except for discovery of the types of parameters.
+ */
+class ParamConverterListener implements EventSubscriberInterface
+{
+    /**
+     * @var \LoyaltyCorp\RequestHandlers\Request\Interfaces\ParamConverterManagerInterface
+     */
+    private $manager;
+
+    /**
+     * Constructor
+     *
+     * @param \LoyaltyCorp\RequestHandlers\Request\Interfaces\ParamConverterManagerInterface $manager
+     */
+    public function __construct(ParamConverterManagerInterface $manager)
+    {
+        $this->manager = $manager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::CONTROLLER => 'onKernelController'
+        ];
+    }
+
+    /**
+     * Listens for the onKernelController event to apply param converters to request
+     * attributes.
+     *
+     * @param \Symfony\Component\HttpKernel\Event\FilterControllerEvent $event
+     *
+     * @return void
+     *
+     * @throws \ReflectionException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\InvalidRequestAttributeException
+     */
+    public function onKernelController(FilterControllerEvent $event): void
+    {
+        $controller = $event->getController();
+        $request = $event->getRequest();
+
+        $configurations = $this->getConfigurations($request);
+
+        $this->configureTypes($configurations, $controller);
+
+        $this->manager->apply($request, $configurations);
+    }
+
+    /**
+     * Looks over all parameters of the controller callable and resolves types of
+     * any configurations that do not have a type specified.
+     *
+     * @param \Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter[] $configurations
+     * @param callable $controller
+     *
+     * @return void
+     *
+     * @throws \ReflectionException
+     */
+    private function configureTypes(array $configurations, callable $controller): void
+    {
+        $reflection = $this->getReflection($controller);
+
+        foreach ($reflection->getParameters() as $parameter) {
+            $class = $parameter->getClass();
+            $hasType = $parameter->hasType();
+
+            if ($class === null && $hasType === false) {
+                // The parameter has no type defined so we cant use it to enrich.
+                continue;
+            }
+
+            if (\array_key_exists($parameter->getName(), $configurations) === false) {
+                // We dont have a configuration that matches the parameter.
+                continue;
+            }
+
+            $configuration = $configurations[$parameter->getName()];
+
+            if ($class !== null && $configuration->getClass() === null) {
+                // Configuration does not have a class set, but we have one.
+
+                $configuration->setClass($class->getName());
+            }
+
+            // If we have a scalar type that allows null
+            $typeOptional = $hasType &&
+                $parameter->getType() !== null &&
+                $parameter->getType()->allowsNull();
+
+            // If the parameter is optional or there is a default value
+            $isOptional = $parameter->isOptional() ||
+                $parameter->isDefaultValueAvailable();
+
+            $configuration->setIsOptional($isOptional || $typeOptional);
+        }
+    }
+
+    /**
+     * Returns an array of ConfigurationInterface objects from the controller.
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *
+     * @return \Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter[]
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\InvalidRequestAttributeException
+     */
+    private function getConfigurations(Request $request): array
+    {
+        $converters = $request->attributes->get('_converters');
+
+        if (\is_array($converters) === false && $converters !== null) {
+            throw new InvalidRequestAttributeException(
+                'The _converters key did not contain an array of param converter configurations.'
+            );
+        }
+
+        $configurations = [];
+
+        foreach ((array)$converters as $configuration) {
+            if (($configuration instanceof ParamConverter) === false) {
+                continue;
+            }
+
+            /**
+             * @var \Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter $configuration
+             *
+             * @see https://youtrack.jetbrains.com/issue/WI-37859 - typehint required until PhpStorm recognises === chec
+             */
+            $configurations[$configuration->getName()] = $configuration;
+        }
+
+        return $configurations;
+    }
+
+    /**
+     * Returns the reflection method for the controller callable.
+     *
+     * @param callable $controller
+     *
+     * @return \ReflectionFunctionAbstract
+     *
+     * @throws \ReflectionException
+     */
+    private function getReflection(callable $controller): ReflectionFunctionAbstract
+    {
+        if (\is_array($controller)) {
+            return new \ReflectionMethod($controller[0], $controller[1]);
+        }
+
+        if (\is_object($controller) && \is_callable([$controller, '__invoke'])) {
+            return new \ReflectionMethod($controller, '__invoke');
+        }
+
+        return new \ReflectionFunction($controller);
+    }
+}

--- a/src/Exceptions/InvalidRequestAttributeException.php
+++ b/src/Exceptions/InvalidRequestAttributeException.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Exceptions;
+
+use EoneoPay\Utils\Exceptions\BaseException;
+
+class InvalidRequestAttributeException extends BaseException
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorCode(): int
+    {
+        return 60;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorSubCode(): int
+    {
+        return 1;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStatusCode(): int
+    {
+        return static::DEFAULT_STATUS_CODE_RUNTIME;
+    }
+}

--- a/src/Exceptions/ParamConverterMisconfiguredException.php
+++ b/src/Exceptions/ParamConverterMisconfiguredException.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Exceptions;
+
+use EoneoPay\Utils\Exceptions\BaseException;
+
+class ParamConverterMisconfiguredException extends BaseException
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorCode(): int
+    {
+        return 50;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorSubCode(): int
+    {
+        return 1;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStatusCode(): int
+    {
+        return static::DEFAULT_STATUS_CODE_RUNTIME;
+    }
+}

--- a/src/Middleware/ParamConverterMiddleware.php
+++ b/src/Middleware/ParamConverterMiddleware.php
@@ -7,8 +7,8 @@ use Closure;
 use EoneoPay\Utils\Bridge\Lumen\Resolvers\ControllerResolver;
 use Illuminate\Http\Request;
 use LoyaltyCorp\RequestHandlers\Event\FilterControllerEvent;
+use LoyaltyCorp\RequestHandlers\EventListeners\ParamConverterListener;
 use Sensio\Bundle\FrameworkExtraBundle\EventListener\ControllerListener;
-use Sensio\Bundle\FrameworkExtraBundle\EventListener\ParamConverterListener;
 
 final class ParamConverterMiddleware
 {
@@ -23,7 +23,7 @@ final class ParamConverterMiddleware
     private $controllerResolver;
 
     /**
-     * @var \Sensio\Bundle\FrameworkExtraBundle\EventListener\ParamConverterListener
+     * @var \LoyaltyCorp\RequestHandlers\EventListeners\ParamConverterListener
      */
     private $listener;
 
@@ -32,7 +32,7 @@ final class ParamConverterMiddleware
      *
      * @param \Sensio\Bundle\FrameworkExtraBundle\EventListener\ControllerListener $controllerListener
      * @param \EoneoPay\Utils\Bridge\Lumen\Resolvers\ControllerResolver $controllerResolver
-     * @param \Sensio\Bundle\FrameworkExtraBundle\EventListener\ParamConverterListener $converterListener
+     * @param \LoyaltyCorp\RequestHandlers\EventListeners\ParamConverterListener $converterListener
      */
     public function __construct(
         ControllerListener $controllerListener,
@@ -51,6 +51,9 @@ final class ParamConverterMiddleware
      * @param \Closure $next
      *
      * @return mixed
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\InvalidRequestAttributeException
+     * @throws \ReflectionException
      */
     public function handle(Request $request, Closure $next)
     {

--- a/src/Request/Interfaces/ParamConverterManagerInterface.php
+++ b/src/Request/Interfaces/ParamConverterManagerInterface.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Request\Interfaces;
+
+use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+interface ParamConverterManagerInterface
+{
+    /**
+     * Adds a param converter to the manager.
+     *
+     * A null priority means the converter will not be iterated over while trying to process
+     * a configuration and it must be explicitly named by the configuration.
+     *
+     * @param \Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface $converter
+     * @param int|null $priority
+     * @param null|string $name
+     *
+     * @return void
+     */
+    public function add(ParamConverterInterface $converter, ?int $priority, ?string $name): void;
+
+    /**
+     * Applies param converter configurations to a request.
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param \Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter[] $configurations
+     *
+     * @return void
+     */
+    public function apply(Request $request, array $configurations): void;
+}

--- a/src/Request/ParamConverterManager.php
+++ b/src/Request/ParamConverterManager.php
@@ -1,0 +1,183 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Request;
+
+use LoyaltyCorp\RequestHandlers\Exceptions\ParamConverterMisconfiguredException;
+use LoyaltyCorp\RequestHandlers\Request\Interfaces\ParamConverterManagerInterface;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * This class implements similar functionality to the Sensio FrameworkExtra bundle's
+ * ParamConverterManager.
+ *
+ * The primary purpose of this class it to apply configurated param converters against
+ * a supplied request.
+ *
+ * Reasons for adding our own:
+ * - Added an interface (so it can be stubbed in our customised ParamConverterListener)
+ * - Throw an exception when a configuration is not processed by any param converters.
+ */
+class ParamConverterManager implements ParamConverterManagerInterface
+{
+    /**
+     * Converters sorted by priority
+     *
+     * @var \Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface[][]
+     */
+    private $converters = [];
+
+    /**
+     * Converters that have explicit names
+     *
+     * @var \Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface[]
+     */
+    private $namedConverters = [];
+
+    /**
+     * Adds a parameter converter.
+     *
+     * Converters match either explicitly via $name or by iteration over all
+     * converters with a $priority. If you pass a $priority = null then the
+     * added converter will not be part of the iteration chain and can only
+     * be invoked explicitly.
+     *
+     * @param \Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface $converter
+     * @param int|null $priority
+     * @param string|null $name
+     *
+     * @return void
+     */
+    public function add(ParamConverterInterface $converter, ?int $priority, ?string $name): void
+    {
+        if (\array_key_exists($priority, $this->converters) === false) {
+            $this->converters[$priority] = [];
+        }
+
+        $this->converters[$priority][] = $converter;
+
+        if ($name !== null) {
+            $this->namedConverters[$name] = $converter;
+        }
+    }
+
+    /**
+     * Returns all registered param converters.
+     *
+     * @return \Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface[]
+     */
+    public function all(): array
+    {
+        \krsort($this->converters);
+
+        return \array_merge(...$this->converters);
+    }
+
+    /**
+     * Applies all converters to the passed configurations and stops when a
+     * converter is applied it will move on to the next configuration and so on.
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param \Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface[] $configurations
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\ParamConverterMisconfiguredException
+     */
+    public function apply(Request $request, array $configurations): void
+    {
+        foreach ($configurations as $configuration) {
+            $this->applyConverter($request, $configuration);
+        }
+    }
+
+    /**
+     * Applies converter on request based on the given configuration.
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param \Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter $configuration
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\ParamConverterMisconfiguredException
+     */
+    private function applyConverter(Request $request, ParamConverter $configuration): void
+    {
+        $value = $request->attributes->get($configuration->getName());
+        $className = $configuration->getClass();
+
+        // If the value is already an instance of the class we are trying to convert it into
+        // we should continue as no conversion is required
+        if (\is_object($value) && $value instanceof $className) {
+            return;
+        }
+
+        if ($configuration->getConverter() !== null) {
+            $this->runNamedConverter($configuration, $request);
+
+            return;
+        }
+
+        foreach ($this->all() as $converter) {
+            if ($converter->supports($configuration) !== true) {
+                continue;
+            }
+
+            if ($converter->apply($request, $configuration) === true) {
+                return;
+            }
+        }
+
+        // If we got here, no converters supported the configuration.
+        throw new ParamConverterMisconfiguredException(\sprintf(
+            'The ParamConverter for "%s" was not processed by any known converters.',
+            $configuration->getName()
+        ));
+    }
+
+    /**
+     * Finds and runs a named converter against the configuration.
+     *
+     * @param \Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter $configuration
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\ParamConverterMisconfiguredException
+     */
+    private function runNamedConverter(ParamConverter $configuration, Request $request): void
+    {
+        $name = $configuration->getConverter();
+
+        if (\array_key_exists($name, $this->namedConverters) === false) {
+            throw new ParamConverterMisconfiguredException(\sprintf(
+                'No converter named "%s" found for conversion of parameter "%s".',
+                $name,
+                $configuration->getName()
+            ));
+        }
+
+        $converter = $this->namedConverters[$name];
+
+        if ($converter->supports($configuration) === false) {
+            throw new ParamConverterMisconfiguredException(\sprintf(
+                'Converter "%s" does not support conversion of parameter "%s".',
+                $name,
+                $configuration->getName()
+            ));
+        }
+
+        if ($converter->apply($request, $configuration) === true) {
+            return;
+        }
+
+        // If we got here, the converter didnt not support apply the result.
+        throw new ParamConverterMisconfiguredException(\sprintf(
+            'The converter "%s" did not run for property "%s".',
+            $name,
+            $configuration->getName()
+        ));
+    }
+}

--- a/src/Request/ParamConverterManager.php
+++ b/src/Request/ParamConverterManager.php
@@ -52,11 +52,13 @@ class ParamConverterManager implements ParamConverterManagerInterface
      */
     public function add(ParamConverterInterface $converter, ?int $priority, ?string $name): void
     {
-        if (\array_key_exists($priority, $this->converters) === false) {
-            $this->converters[$priority] = [];
-        }
+        if ($priority !== null) {
+            if (\array_key_exists($priority, $this->converters) === false) {
+                $this->converters[$priority] = [];
+            }
 
-        $this->converters[$priority][] = $converter;
+            $this->converters[$priority][] = $converter;
+        }
 
         if ($name !== null) {
             $this->namedConverters[$name] = $converter;
@@ -80,7 +82,7 @@ class ParamConverterManager implements ParamConverterManagerInterface
      * converter is applied it will move on to the next configuration and so on.
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param \Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface[] $configurations
+     * @param \Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter[] $configurations
      *
      * @return void
      *
@@ -110,7 +112,7 @@ class ParamConverterManager implements ParamConverterManagerInterface
 
         // If the value is already an instance of the class we are trying to convert it into
         // we should continue as no conversion is required
-        if (\is_object($value) && $value instanceof $className) {
+        if (\is_object($value) === true && ($value instanceof $className) === true) {
             return;
         }
 

--- a/tests/EventListeners/Fixtures/TestController.php
+++ b/tests/EventListeners/Fixtures/TestController.php
@@ -7,6 +7,8 @@ use stdClass;
 
 /**
  * @coversNothing
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class TestController
 {

--- a/tests/EventListeners/Fixtures/TestController.php
+++ b/tests/EventListeners/Fixtures/TestController.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\EventListeners\Fixtures;
+
+use stdClass;
+
+/**
+ * @coversNothing
+ */
+class TestController
+{
+    /**
+     * Invokable callable.
+     *
+     * @return void
+     */
+    public function __invoke(): void
+    {
+    }
+
+    /**
+     * A callable with no configuration.
+     *
+     * @param \stdClass $parameter
+     *
+     * @return void
+     */
+    public function method(?stdClass $parameter): void
+    {
+    }
+
+    /**
+     * Mixed type parameter.
+     *
+     * @param mixed $parameter
+     *
+     * @return void
+     */
+    public function untyped($parameter): void
+    {
+    }
+}

--- a/tests/EventListeners/ParamConverterListenerTest.php
+++ b/tests/EventListeners/ParamConverterListenerTest.php
@@ -6,6 +6,7 @@ namespace Tests\LoyaltyCorp\RequestHandlers\EventListeners;
 use LoyaltyCorp\RequestHandlers\Event\FilterControllerEvent;
 use LoyaltyCorp\RequestHandlers\EventListeners\ParamConverterListener;
 use LoyaltyCorp\RequestHandlers\Exceptions\InvalidRequestAttributeException;
+use LoyaltyCorp\RequestHandlers\Exceptions\ParamConverterMisconfiguredException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use stdClass;
 use Symfony\Component\HttpFoundation\Request;
@@ -16,6 +17,8 @@ use Tests\LoyaltyCorp\RequestHandlers\TestCase;
 
 /**
  * @covers \LoyaltyCorp\RequestHandlers\EventListeners\ParamConverterListener
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess) Listener interface requires static call
  */
 class ParamConverterListenerTest extends TestCase
 {

--- a/tests/EventListeners/ParamConverterListenerTest.php
+++ b/tests/EventListeners/ParamConverterListenerTest.php
@@ -1,0 +1,212 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\EventListeners;
+
+use LoyaltyCorp\RequestHandlers\Event\FilterControllerEvent;
+use LoyaltyCorp\RequestHandlers\EventListeners\ParamConverterListener;
+use LoyaltyCorp\RequestHandlers\Exceptions\InvalidRequestAttributeException;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use stdClass;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Tests\LoyaltyCorp\RequestHandlers\EventListeners\Fixtures\TestController;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Request\ParamConverterManagerStub;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\RequestHandlers\EventListeners\ParamConverterListener
+ */
+class ParamConverterListenerTest extends TestCase
+{
+    /**
+     * Tests the getSubscribedEvents method.
+     *
+     * @return void
+     */
+    public function testGetSubscribedEvents(): void
+    {
+        $expectedEvents = [
+            KernelEvents::CONTROLLER => 'onKernelController'
+        ];
+
+        static::assertSame($expectedEvents, ParamConverterListener::getSubscribedEvents());
+    }
+
+    /**
+     * Tests the listener when _converters isnt an array.
+     *
+     * @return void
+     *
+     * @throws \ReflectionException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\InvalidRequestAttributeException
+     */
+    public function testOnKernelControllerBadConverters(): void
+    {
+        $controller = new TestController();
+        $request = new Request();
+        $request->attributes->set('_converters', false);
+
+        $event = new FilterControllerEvent(
+            [$controller, 'method'],
+            $request
+        );
+
+        $manager = new ParamConverterManagerStub();
+        $listener = new ParamConverterListener($manager);
+
+        $this->expectException(InvalidRequestAttributeException::class);
+        $this->expectExceptionMessage(
+            'The _converters key did not contain an array of param converter configurations.'
+        );
+
+        $listener->onKernelController($event);
+    }
+
+    /**
+     * Tests the listener
+     *
+     * @return void
+     *
+     * @throws \ReflectionException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\InvalidRequestAttributeException
+     */
+    public function testOnKernelControllerConverters(): void
+    {
+        $controller = new TestController();
+        $paramConverter = new ParamConverter([]);
+        $paramConverter->setName('parameter');
+
+        $request = new Request();
+        $request->attributes->set('_converters', [
+            $paramConverter,
+            new stdClass()
+        ]);
+
+        $expected = [
+            'parameter' => $paramConverter
+        ];
+
+        $event = new FilterControllerEvent(
+            [$controller, 'method'],
+            $request
+        );
+
+        $manager = new ParamConverterManagerStub();
+        $listener = new ParamConverterListener($manager);
+
+        $listener->onKernelController($event);
+
+        static::assertSame($expected, $manager->getConfigurations());
+        static::assertTrue($paramConverter->isOptional());
+        static::assertSame(stdClass::class, $paramConverter->getClass());
+    }
+
+    /**
+     * Tests the listener when no type information available
+     *
+     * @return void
+     *
+     * @throws \ReflectionException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\InvalidRequestAttributeException
+     */
+    public function testOnKernelControllerConvertersNoType(): void
+    {
+        $controller = new TestController();
+        $paramConverter = new ParamConverter([]);
+        $paramConverter->setName('untyped');
+
+        $request = new Request();
+        $request->attributes->set('_converters', [
+            $paramConverter,
+            new stdClass()
+        ]);
+
+        $event = new FilterControllerEvent(
+            [$controller, 'untyped'],
+            $request
+        );
+
+        $manager = new ParamConverterManagerStub();
+        $listener = new ParamConverterListener($manager);
+
+        $listener->onKernelController($event);
+
+        static::assertFalse($paramConverter->isOptional());
+        static::assertNull($paramConverter->getClass());
+    }
+
+    /**
+     * Tests the listener when no configuration is presented.
+     *
+     * @return void
+     *
+     * @throws \ReflectionException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\InvalidRequestAttributeException
+     */
+    public function testOnKernelControllerNoConfiguration(): void
+    {
+        $controller = new TestController();
+        $event = new FilterControllerEvent(
+            [$controller, 'method'],
+            new Request()
+        );
+
+        $manager = new ParamConverterManagerStub();
+        $listener = new ParamConverterListener($manager);
+
+        $listener->onKernelController($event);
+
+        // Nothing should happen.
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * Tests the listener when no configuration is presented.
+     *
+     * @return void
+     *
+     * @throws \ReflectionException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\InvalidRequestAttributeException
+     */
+    public function testOnKernelControllerNoConfigurationCallable(): void
+    {
+        $event = new FilterControllerEvent(
+            'trim',
+            new Request()
+        );
+
+        $manager = new ParamConverterManagerStub();
+        $listener = new ParamConverterListener($manager);
+
+        $listener->onKernelController($event);
+
+        // Nothing should happen.
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * Tests the listener when no configuration is presented.
+     *
+     * @return void
+     *
+     * @throws \ReflectionException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\InvalidRequestAttributeException
+     */
+    public function testOnKernelControllerNoConfigurationInvokable(): void
+    {
+        $controller = new TestController();
+        $event = new FilterControllerEvent(
+            $controller,
+            new Request()
+        );
+
+        $manager = new ParamConverterManagerStub();
+        $listener = new ParamConverterListener($manager);
+
+        $listener->onKernelController($event);
+
+        // Nothing should happen.
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/EventListeners/ParamConverterListenerTest.php
+++ b/tests/EventListeners/ParamConverterListenerTest.php
@@ -6,7 +6,6 @@ namespace Tests\LoyaltyCorp\RequestHandlers\EventListeners;
 use LoyaltyCorp\RequestHandlers\Event\FilterControllerEvent;
 use LoyaltyCorp\RequestHandlers\EventListeners\ParamConverterListener;
 use LoyaltyCorp\RequestHandlers\Exceptions\InvalidRequestAttributeException;
-use LoyaltyCorp\RequestHandlers\Exceptions\ParamConverterMisconfiguredException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use stdClass;
 use Symfony\Component\HttpFoundation\Request;

--- a/tests/Exceptions/InvalidRequestAttributeExceptionTest.php
+++ b/tests/Exceptions/InvalidRequestAttributeExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Exceptions;
+
+use LoyaltyCorp\RequestHandlers\Exceptions\InvalidRequestAttributeException;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\RequestHandlers\Exceptions\InvalidRequestAttributeException
+ */
+class InvalidRequestAttributeExceptionTest extends TestCase
+{
+    /**
+     * Tests methods on EntityNotFoundException
+     *
+     * @return void
+     */
+    public function testExceptionMethods(): void
+    {
+        $exception = new InvalidRequestAttributeException();
+
+        self::assertSame(1, $exception->getErrorSubCode());
+        self::assertSame(60, $exception->getErrorCode());
+        self::assertSame(500, $exception->getStatusCode());
+    }
+}

--- a/tests/Exceptions/ParamConverterMisconfiguredExceptionTest.php
+++ b/tests/Exceptions/ParamConverterMisconfiguredExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Exceptions;
+
+use LoyaltyCorp\RequestHandlers\Exceptions\ParamConverterMisconfiguredException;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\RequestHandlers\Exceptions\ParamConverterMisconfiguredException
+ */
+class ParamConverterMisconfiguredExceptionTest extends TestCase
+{
+    /**
+     * Tests methods on EntityNotFoundException
+     *
+     * @return void
+     */
+    public function testExceptionMethods(): void
+    {
+        $exception = new ParamConverterMisconfiguredException();
+
+        self::assertSame(1, $exception->getErrorSubCode());
+        self::assertSame(50, $exception->getErrorCode());
+        self::assertSame(500, $exception->getStatusCode());
+    }
+}

--- a/tests/Integration/Fixtures/Controller.php
+++ b/tests/Integration/Fixtures/Controller.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Tests\LoyaltyCorp\RequestHandlers\Integration\Fixtures;
 
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+
 class Controller
 {
     /**
@@ -21,6 +23,8 @@ class Controller
      * @param \Tests\LoyaltyCorp\RequestHandlers\Integration\Fixtures\ThingRequest $request
      *
      * @return void
+     *
+     * @ParamConverter("request")
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -200,7 +200,7 @@ XML;
      *
      * @return void
      *
-     * @throws \EoneoPay\Utils\Exceptions\AnnotationCacheException
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public function testEmptyRequest(): void
     {
@@ -223,8 +223,8 @@ XML;
      *
      * @return void
      *
-     * @throws \EoneoPay\Utils\Exceptions\AnnotationCacheException
      * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      *
      * @dataProvider getSuccessData
      */
@@ -266,7 +266,7 @@ XML;
      *
      * @return void
      *
-     * @throws \EoneoPay\Utils\Exceptions\AnnotationCacheException
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public function testValidationFailure(): void
     {

--- a/tests/Middleware/ParamConverterMiddlewareTest.php
+++ b/tests/Middleware/ParamConverterMiddlewareTest.php
@@ -6,9 +6,9 @@ namespace Tests\LoyaltyCorp\RequestHandlers\Middleware;
 use EoneoPay\Utils\Bridge\Lumen\Resolvers\ControllerResolver;
 use Illuminate\Container\Container;
 use Illuminate\Http\Request;
+use LoyaltyCorp\RequestHandlers\EventListeners\ParamConverterListener;
 use LoyaltyCorp\RequestHandlers\Middleware\ParamConverterMiddleware;
 use Sensio\Bundle\FrameworkExtraBundle\EventListener\ControllerListener;
-use Sensio\Bundle\FrameworkExtraBundle\EventListener\ParamConverterListener;
 use Tests\LoyaltyCorp\RequestHandlers\TestCase;
 
 /**

--- a/tests/Request/ParamConverterManagerTest.php
+++ b/tests/Request/ParamConverterManagerTest.php
@@ -1,0 +1,221 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Request;
+
+use LoyaltyCorp\RequestHandlers\Exceptions\ParamConverterMisconfiguredException;
+use LoyaltyCorp\RequestHandlers\Request\ParamConverterManager;
+use ReflectionProperty;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use stdClass;
+use Symfony\Component\HttpFoundation\Request;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Sensio\ParamConverterStub;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\RequestHandlers\Request\ParamConverterManager
+ */
+class ParamConverterManagerTest extends TestCase
+{
+    /**
+     * Tests adding providers and priority sorting.
+     *
+     * @return void
+     *
+     * @throws \ReflectionException
+     */
+    public function testAddingConverters(): void
+    {
+        $manager = new ParamConverterManager();
+        $manager->add($stub1 = new ParamConverterStub(), 0, 'stub1');
+        $manager->add($stub2 = new ParamConverterStub(), 1, 'stub2');
+        $manager->add($stub3 = new ParamConverterStub(), 2, 'stub3');
+        $manager->add($stub4 = new ParamConverterStub(), 0, null);
+
+        $expectedPriority = [$stub3, $stub2, $stub1, $stub4];
+        $expectedNamed = [
+            'stub1' => $stub1,
+            'stub2' => $stub2,
+            'stub3' => $stub3
+        ];
+
+        $priorityConverters = $manager->all();
+
+        // Hax alert. Dont do this :(
+        $reflectionProperty = new ReflectionProperty($manager, 'namedConverters');
+        $reflectionProperty->setAccessible(true);
+        $namedConverters = $reflectionProperty->getValue($manager);
+
+        static::assertSame($expectedPriority, $priorityConverters);
+        static::assertSame($expectedNamed, $namedConverters);
+    }
+
+    /**
+     * Tests apply will bail when the property is already set to the expected class.
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\ParamConverterMisconfiguredException
+     */
+    public function testApplyAlreadySet(): void
+    {
+        $manager = new ParamConverterManager();
+        $manager->add(new ParamConverterStub(), 0, null);
+
+        $request = new Request();
+        $request->attributes->set('property', new stdClass());
+
+        $configuration = new ParamConverter([]);
+        $configuration->setName('property');
+        $configuration->setClass(stdClass::class);
+
+        $manager->apply($request, [$configuration]);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * Tests what happens when no param converters do the conversion.
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\ParamConverterMisconfiguredException
+     */
+    public function testApplyConverterApplied(): void
+    {
+        $manager = new ParamConverterManager();
+        $manager->add(new ParamConverterStub([true], [true]), 0, null);
+
+        $configuration = new ParamConverter([]);
+        $configuration->setName('property');
+
+        $manager->apply(new Request(), [$configuration]);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * Tests what happens when no param converters do the conversion.
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\ParamConverterMisconfiguredException
+     */
+    public function testApplyConverterNoneApplied(): void
+    {
+        $manager = new ParamConverterManager();
+        $manager->add(new ParamConverterStub(null, [false]), 0, null);
+
+        $configuration = new ParamConverter([]);
+        $configuration->setName('property');
+
+        $this->expectException(ParamConverterMisconfiguredException::class);
+        $this->expectExceptionMessage('The ParamConverter for "property" was not processed by any known converters.');
+
+        $manager->apply(new Request(), [$configuration]);
+    }
+
+    /**
+     * Tests apply failure when configured converter doesnt convert.
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\ParamConverterMisconfiguredException
+     */
+    public function testApplyNamedConverter(): void
+    {
+        $manager = new ParamConverterManager();
+        $manager->add(new ParamConverterStub([true], [true]), null, 'existent');
+
+        $request = new Request();
+
+        $configuration = new ParamConverter([]);
+        $configuration->setClass(stdClass::class);
+        $configuration->setConverter('existent');
+        $configuration->setName('property');
+
+        $manager->apply($request, [$configuration]);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * Tests apply will throw when named converter doesnt exist.
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\ParamConverterMisconfiguredException
+     */
+    public function testApplyNamedConverterBadName(): void
+    {
+        $manager = new ParamConverterManager();
+
+        $request = new Request();
+
+        $configuration = new ParamConverter([]);
+        $configuration->setClass(stdClass::class);
+        $configuration->setConverter('non-existent');
+        $configuration->setName('property');
+
+        $this->expectException(ParamConverterMisconfiguredException::class);
+        $this->expectExceptionMessage(
+            'No converter named "non-existent" found for conversion of parameter "property".'
+        );
+
+        $manager->apply($request, [$configuration]);
+    }
+
+    /**
+     * Tests apply failure when configured converter doesnt convert.
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\ParamConverterMisconfiguredException
+     */
+    public function testApplyNamedConverterNotApplied(): void
+    {
+        $manager = new ParamConverterManager();
+        $manager->add(new ParamConverterStub([false], [true]), null, 'existent');
+
+        $request = new Request();
+
+        $configuration = new ParamConverter([]);
+        $configuration->setClass(stdClass::class);
+        $configuration->setConverter('existent');
+        $configuration->setName('property');
+
+        $this->expectException(ParamConverterMisconfiguredException::class);
+        $this->expectExceptionMessage(
+            'The converter "existent" did not run for property "property".'
+        );
+
+        $manager->apply($request, [$configuration]);
+    }
+
+    /**
+     * Tests apply will throw when named converter doesnt support the configuration.
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\ParamConverterMisconfiguredException
+     */
+    public function testApplyNamedConverterNotSupported(): void
+    {
+        $manager = new ParamConverterManager();
+        $manager->add(new ParamConverterStub(null, [false]), null, 'existent');
+
+        $request = new Request();
+
+        $configuration = new ParamConverter([]);
+        $configuration->setClass(stdClass::class);
+        $configuration->setConverter('existent');
+        $configuration->setName('property');
+
+        $this->expectException(ParamConverterMisconfiguredException::class);
+        $this->expectExceptionMessage(
+            'Converter "existent" does not support conversion of parameter "property".'
+        );
+
+        $manager->apply($request, [$configuration]);
+    }
+}

--- a/tests/Stubs/Request/ParamConverterManagerStub.php
+++ b/tests/Stubs/Request/ParamConverterManagerStub.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Stubs\Request;
+
+use LoyaltyCorp\RequestHandlers\Request\Interfaces\ParamConverterManagerInterface;
+use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class ParamConverterManagerStub implements ParamConverterManagerInterface
+{
+    /**
+     * @var mixed[]
+     */
+    private $configurations;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add(ParamConverterInterface $converter, ?int $priority, ?string $name): void
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply(Request $request, array $configurations): void
+    {
+        $this->configurations = $configurations;
+    }
+
+    /**
+     * Returns configurations from last call.
+     *
+     * @return mixed[]
+     */
+    public function getConfigurations(): array
+    {
+        return $this->configurations;
+    }
+}

--- a/tests/Stubs/Vendor/Sensio/ParamConverterStub.php
+++ b/tests/Stubs/Vendor/Sensio/ParamConverterStub.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Sensio;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class ParamConverterStub implements ParamConverterInterface
+{
+    /**
+     * Returns for the apply function.
+     *
+     * @var bool[]
+     */
+    private $returnApply;
+
+    /**
+     * Returns for the supports function.
+     *
+     * @var bool[]
+     */
+    private $returnSupports;
+
+    /**
+     * Constructor
+     *
+     * @param bool[]|null $returnApply
+     * @param bool[]|null $returnSupports
+     */
+    public function __construct(?array $returnApply = null, ?array $returnSupports = null)
+    {
+        $this->returnApply = $returnApply ?? [false];
+        $this->returnSupports = $returnSupports ?? [false];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply(Request $request, ParamConverter $configuration): bool
+    {
+        return \array_shift($this->returnApply) ?? true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(ParamConverter $configuration): bool
+    {
+        return \array_shift($this->returnSupports) ?? true;
+    }
+}


### PR DESCRIPTION
This PR aims to configure the param converter process to better suit our needs:

- Disables auto configuration which will require @ParamConverter annotations for all request objects
- Throws exceptions if param converters are defined that dont result in some kind of action taking place.

More detail is added to both the ParamConverterListener and ParamConverterManager class docs.