### PR TITLE
PYMT-948 Fix request validation exception

### DIFF
--- a/src/Exceptions/RequestValidationException.php
+++ b/src/Exceptions/RequestValidationException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace LoyaltyCorp\RequestHandlers\Exceptions;
 
 use EoneoPay\Utils\Exceptions\BaseException;
-use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+use LoyaltyCorp\RequestHandlers\Serializer\Converters\CamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Throwable;
 

--- a/src/Serializer/Converters/CamelCaseToSnakeCaseNameConverter.php
+++ b/src/Serializer/Converters/CamelCaseToSnakeCaseNameConverter.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Serializer\Converters;
+
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+
+/**
+ * This class helps convert camel case property name to snake case. It will skip any part of the property name string
+ * which it identifies as an array key.
+ */
+class CamelCaseToSnakeCaseNameConverter implements NameConverterInterface
+{
+    /**
+     * List of attributes.
+     *
+     * @var mixed[]|null
+     */
+    private $attributes;
+
+    /**
+     * Is lower camel-case.
+     *
+     * @var bool
+     */
+    private $lowerCamelCase;
+
+    /**
+     * @param mixed[]|null $attributes The list of attributes to rename or null for all attributes
+     * @param bool $lowerCamelCase Use lower camel-case style
+     */
+    public function __construct(?array $attributes = null, ?bool $lowerCamelCase = null)
+    {
+        $this->attributes = $attributes;
+        $this->lowerCamelCase = $lowerCamelCase ?? true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function denormalize($propertyName): string
+    {
+        /** @var string $camelCasedName */
+        $camelCasedName = \preg_replace_callback('/(^|_|\.)+(.)|\[.*?\]/', static function ($match) {
+            // If the token starts with a '[' means property has array so do not perform any modifications,
+            // just return same.
+            if (\mb_strpos($match[0], '[') === 0) {
+                return $match[0];
+            }
+            if (isset($match[1]) === true && $match[1] === '.') {
+                return $match[0];
+            }
+            return \mb_strtoupper($match[2]);
+        }, $propertyName) ?: '';
+
+        if ($this->lowerCamelCase === true) {
+            $camelCasedName = \lcfirst($camelCasedName);
+        }
+
+        if ($this->attributes === null || \in_array($camelCasedName, $this->attributes, true)) {
+            return $camelCasedName;
+        }
+
+        return $propertyName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($propertyName): string
+    {
+        if ($this->attributes === null || \in_array($propertyName, $this->attributes, true) === true) {
+            return \preg_replace_callback('/[A-Z]|\[.*?\]/', static function ($match) {
+                // If the token starts with a '[' means property has array so do not perform any modifications,
+                // just return same.
+                if (\mb_strpos($match[0], '[') === 0) {
+                    return $match[0];
+                }
+                /** @var string $normalized */
+                $normalized = \preg_replace('/['.$match[0].']/', '_\\0', $match[0]);
+                return \mb_strtolower($normalized);
+            }, \lcfirst($propertyName)) ?: '';
+        }
+
+        return $propertyName;
+    }
+}

--- a/tests/Serializer/Converters/CamelCaseToSnakeCaseNameConverterTest.php
+++ b/tests/Serializer/Converters/CamelCaseToSnakeCaseNameConverterTest.php
@@ -14,7 +14,7 @@ class CamelCaseToSnakeCaseNameConverterTest extends TestCase
     /**
      * Get property names data set for name converter tests.
      *
-     * @return iterable
+     * @return mixed[][]
      */
     public function getPropertyNamesDataSet(): iterable
     {

--- a/tests/Serializer/Converters/CamelCaseToSnakeCaseNameConverterTest.php
+++ b/tests/Serializer/Converters/CamelCaseToSnakeCaseNameConverterTest.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Serializer\Converters;
+
+use LoyaltyCorp\RequestHandlers\Serializer\Converters\CamelCaseToSnakeCaseNameConverter;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\RequestHandlers\Serializer\Converters\CamelCaseToSnakeCaseNameConverter
+ */
+class CamelCaseToSnakeCaseNameConverterTest extends TestCase
+{
+    /**
+     * Test de-normalizing a property name results in expected value.
+     *
+     * @return void
+     */
+    public function testDenormalize(): void
+    {
+        $expectedValue1 = 'headerStuff[APPLICATION_ID].property';
+        $expectedValue2 = 'headerStuffStuff[APPLICATION_ID].property';
+        $expectedValue3 = 'headerStuff[APPLICATION_ID].propertyId';
+        $expectedValue4 = 'propertyName';
+        $expectedValue5 = 'property';
+
+        $actualValue1 = $this->getConverter()->denormalize('header_stuff[APPLICATION_ID].property');
+        $actualValue2 = $this->getConverter()->denormalize('header_stuff_stuff[APPLICATION_ID].property');
+        $actualValue3 = $this->getConverter()->denormalize('header_stuff[APPLICATION_ID].property_id');
+        $actualValue4 = $this->getConverter()->denormalize('property_name');
+        $actualValue5 = $this->getConverter(['random'])->denormalize('property');
+
+        static::assertSame($expectedValue1, $actualValue1);
+        static::assertSame($expectedValue2, $actualValue2);
+        static::assertSame($expectedValue3, $actualValue3);
+        static::assertSame($expectedValue4, $actualValue4);
+        static::assertSame($expectedValue5, $actualValue5);
+    }
+
+    /**
+     * Test normalizing a property name results in expected value.
+     *
+     * @return void
+     */
+    public function testNormalize(): void
+    {
+        $expectedValue1 = 'header_stuff[APPLICATION_ID].property';
+        $expectedValue2 = 'header_stuff_stuff[APPLICATION_ID].property';
+        $expectedValue3 = 'header_stuff[APPLICATION_ID].property_id';
+        $expectedValue4 = 'property_name';
+        $expectedValue5 = 'property';
+
+        $actualValue1 = $this->getConverter()->normalize('headerStuff[APPLICATION_ID].property');
+        $actualValue2 = $this->getConverter()->normalize('headerStuffStuff[APPLICATION_ID].property');
+        $actualValue3 = $this->getConverter()->normalize('headerStuff[APPLICATION_ID].propertyId');
+        $actualValue4 = $this->getConverter()->normalize('propertyName');
+        $actualValue5 = $this->getConverter(['random'])->normalize('property');
+
+        static::assertSame($expectedValue1, $actualValue1);
+        static::assertSame($expectedValue2, $actualValue2);
+        static::assertSame($expectedValue3, $actualValue3);
+        static::assertSame($expectedValue4, $actualValue4);
+        static::assertSame($expectedValue5, $actualValue5);
+    }
+
+    /**
+     * Get camel case to snake case converter.
+     *
+     * @param mixed[]|null $attributes List of attributes
+     * @param bool|null $isLowerCamelCase Is lower camel-case.
+     *
+     * @return \LoyaltyCorp\RequestHandlers\Serializer\Converters\CamelCaseToSnakeCaseNameConverter
+     */
+    private function getConverter(
+        ?array $attributes = null,
+        ?bool $isLowerCamelCase = null
+    ): CamelCaseToSnakeCaseNameConverter {
+        return new CamelCaseToSnakeCaseNameConverter($attributes, $isLowerCamelCase);
+    }
+}

--- a/tests/Serializer/Converters/CamelCaseToSnakeCaseNameConverterTest.php
+++ b/tests/Serializer/Converters/CamelCaseToSnakeCaseNameConverterTest.php
@@ -12,55 +12,110 @@ use Tests\LoyaltyCorp\RequestHandlers\TestCase;
 class CamelCaseToSnakeCaseNameConverterTest extends TestCase
 {
     /**
+     * Get property names data set for name converter tests.
+     *
+     * @return iterable
+     */
+    public function getPropertyNamesDataSet(): iterable
+    {
+        yield [
+            'Property name with array key 1' => [
+                'denormalized' => 'headerStuff[APPLICATION_ID].property',
+                'normalized' => 'header_stuff[APPLICATION_ID].property'
+            ]
+        ];
+        yield [
+            'Property name with array key 2' => [
+                'denormalized' => 'headerStuffStuff[APPLICATION_ID].property',
+                'normalized' => 'header_stuff_stuff[APPLICATION_ID].property'
+            ]
+        ];
+        yield [
+            'Property name with array key 3' => [
+                'denormalized' => 'headerStuff[APPLICATION_ID].propertyId',
+                'normalized' => 'header_stuff[APPLICATION_ID].property_id'
+            ]
+        ];
+        yield [
+            'Property name no array key 1' => [
+                'denormalized' => 'propertyName',
+                'normalized' => 'property_name'
+            ]
+        ];
+        yield [
+            'Property name no array key 2' => [
+                'denormalized' => 'property',
+                'normalized' => 'property'
+            ]
+        ];
+        yield [
+            'Property name no array key 3' => [
+                'denormalized' => 'property\((Name',
+                'normalized' => 'property\((_name'
+            ]
+        ];
+        yield [
+            'Property name no array key 4' => [
+                'denormalized' => 'property[NAME',
+                'normalized' => 'property[_n_a_m_e'
+            ]
+        ];
+    }
+
+    /**
      * Test de-normalizing a property name results in expected value.
+     *
+     * @param mixed[] $data
+     *
+     * @return void
+     *
+     * @dataProvider getPropertyNamesDataSet()
+     */
+    public function testDenormalize(array $data): void
+    {
+        $actualDenormalized = $this->getConverter()->denormalize($data['normalized']);
+
+        static::assertSame($data['denormalized'], $actualDenormalized);
+    }
+
+    /**
+     * Test de-normalizing a property name results in expected value when attributes are supplied to converter.
      *
      * @return void
      */
-    public function testDenormalize(): void
+    public function testDenormalizeWithProvidedAttributes(): void
     {
-        $expectedValue1 = 'headerStuff[APPLICATION_ID].property';
-        $expectedValue2 = 'headerStuffStuff[APPLICATION_ID].property';
-        $expectedValue3 = 'headerStuff[APPLICATION_ID].propertyId';
-        $expectedValue4 = 'propertyName';
-        $expectedValue5 = 'property';
+        $actualDenormalized = $this->getConverter(['random'])->denormalize('property');
 
-        $actualValue1 = $this->getConverter()->denormalize('header_stuff[APPLICATION_ID].property');
-        $actualValue2 = $this->getConverter()->denormalize('header_stuff_stuff[APPLICATION_ID].property');
-        $actualValue3 = $this->getConverter()->denormalize('header_stuff[APPLICATION_ID].property_id');
-        $actualValue4 = $this->getConverter()->denormalize('property_name');
-        $actualValue5 = $this->getConverter(['random'])->denormalize('property');
-
-        static::assertSame($expectedValue1, $actualValue1);
-        static::assertSame($expectedValue2, $actualValue2);
-        static::assertSame($expectedValue3, $actualValue3);
-        static::assertSame($expectedValue4, $actualValue4);
-        static::assertSame($expectedValue5, $actualValue5);
+        static::assertSame('property', $actualDenormalized);
     }
 
     /**
      * Test normalizing a property name results in expected value.
      *
+     * @param mixed[] $data
+     *
+     * @return void
+     *
+     * @dataProvider getPropertyNamesDataSet()
+     */
+    public function testNormalize(array $data): void
+    {
+        $actualNormalized = $this->getConverter()->normalize($data['denormalized']);
+
+        static::assertSame($data['normalized'], $actualNormalized);
+    }
+
+    /**
+     * Test normalizing a property name results in expected value when attributes are supplied to converter.
+     *
      * @return void
      */
-    public function testNormalize(): void
+    public function testNormalizeWithProvidedAttributes(): void
     {
-        $expectedValue1 = 'header_stuff[APPLICATION_ID].property';
-        $expectedValue2 = 'header_stuff_stuff[APPLICATION_ID].property';
-        $expectedValue3 = 'header_stuff[APPLICATION_ID].property_id';
-        $expectedValue4 = 'property_name';
-        $expectedValue5 = 'property';
+        $actualNormalized = $this->getConverter(['random'])->normalize('property');
 
-        $actualValue1 = $this->getConverter()->normalize('headerStuff[APPLICATION_ID].property');
-        $actualValue2 = $this->getConverter()->normalize('headerStuffStuff[APPLICATION_ID].property');
-        $actualValue3 = $this->getConverter()->normalize('headerStuff[APPLICATION_ID].propertyId');
-        $actualValue4 = $this->getConverter()->normalize('propertyName');
-        $actualValue5 = $this->getConverter(['random'])->normalize('property');
-
-        static::assertSame($expectedValue1, $actualValue1);
-        static::assertSame($expectedValue2, $actualValue2);
-        static::assertSame($expectedValue3, $actualValue3);
-        static::assertSame($expectedValue4, $actualValue4);
-        static::assertSame($expectedValue5, $actualValue5);
+        static::assertSame('property', $actualNormalized);
     }
 
     /**


### PR DESCRIPTION
The `RequestValidationException` has a method `getErrors()` that converts Symfony's `ViolationConstraintList` into an array formatted closer to how Laravel returns its validation errors.

This works well, except when a validation constraint violation occurs with an array key where the property path `headers[APPLICATION_ID]` will get converted to `headers[_a_p_p_l_i_c_a_t_i_o_n_i_d]`.

**Fix:**

Create custom` CamelCaseToSnakeCaseNameConverter` to be used in `RequestValidationException` which normalizes and de-normalizes property path with array keys.

Ticket: [https://loyaltycorp.atlassian.net/browse/PYMT-948](https://loyaltycorp.atlassian.net/browse/PYMT-948)