### PR TITLE
Feature/object builder service

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -65,3 +65,6 @@ parameters:
         -
             message: '#Call to static method PHPUnit\\Framework\\Assert::assertNull\(\) with string will always evaluate to false\.#'
             path: tests/EventListeners/ParamConverterListenerTest.php
+        -
+            message: '#Tests\\LoyaltyCorp\\RequestHandlers\\Stubs\\Vendor\\PhpStan\\ScopeStub::__construct\(\) does not call parent constructor from PHPStan\\Analyser\\Scope\.#'
+            path: tests/Stubs/Vendor/PhpStan/ScopeStub.php

--- a/src/Bridge/Laravel/Providers/ParamConverterProvider.php
+++ b/src/Bridge/Laravel/Providers/ParamConverterProvider.php
@@ -11,6 +11,8 @@ use EoneoPay\Utils\AnnotationReader;
 use FOS\RestBundle\Serializer\SymfonySerializerAdapter;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\ServiceProvider;
+use LoyaltyCorp\RequestHandlers\Builder\Interfaces\ObjectBuilderInterface;
+use LoyaltyCorp\RequestHandlers\Builder\ObjectBuilder;
 use LoyaltyCorp\RequestHandlers\Encoder\JsonEncoder;
 use LoyaltyCorp\RequestHandlers\Encoder\XmlEncoder;
 use LoyaltyCorp\RequestHandlers\EventListeners\ParamConverterListener;
@@ -103,6 +105,12 @@ final class ParamConverterProvider extends ServiceProvider
                 ));
             }
         );
+        $this->app->singleton(ObjectBuilderInterface::class, static function (Container $app): ObjectBuilder {
+            return new ObjectBuilder(
+                $app->make('requesthandlers_serializer'),
+                $app->make(ValidatorInterface::class)
+            );
+        });
         $this->app->singleton(PropertyAccessorInterface::class, static function (): PropertyAccessor {
             return new PropertyAccessor(true);
         });

--- a/src/Bridge/Laravel/Providers/ParamConverterProvider.php
+++ b/src/Bridge/Laravel/Providers/ParamConverterProvider.php
@@ -54,6 +54,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Coupling required to bind services
+ * @SuppressWarnings(PHPMD.ExcessiveMethodLength) register method contains lots of lines
  */
 final class ParamConverterProvider extends ServiceProvider
 {

--- a/src/Bridge/PhpStan/ObjectBuilderReturnTypeExtension.php
+++ b/src/Bridge/PhpStan/ObjectBuilderReturnTypeExtension.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Bridge\PhpStan;
+
+use LoyaltyCorp\RequestHandlers\Builder\Interfaces\ObjectBuilderInterface;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Coupling required due to PHPStan design
+ */
+class ObjectBuilderReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getClass(): string
+    {
+        return ObjectBuilderInterface::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'build' ||
+            $methodReflection->getName() === 'buildWithContext';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \PHPStan\Analyser\UndefinedVariableException
+     * @throws \PHPStan\Broker\ClassAutoloadingException
+     * @throws \PHPStan\Broker\ClassNotFoundException
+     * @throws \PHPStan\Broker\FunctionNotFoundException
+     * @throws \PHPStan\Reflection\MissingConstantFromReflectionException
+     * @throws \PHPStan\Reflection\MissingMethodFromReflectionException
+     * @throws \PHPStan\Reflection\MissingPropertyFromReflectionException
+     * @throws \PHPStan\ShouldNotHappenException
+     */
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
+        $argType = $scope->getType($methodCall->args[0]->value);
+        if ($argType instanceof ConstantStringType === false) {
+            return new MixedType();
+        }
+
+        return new ObjectType($argType->getValue());
+    }
+}

--- a/src/Bridge/PhpStan/extension.neon
+++ b/src/Bridge/PhpStan/extension.neon
@@ -1,0 +1,5 @@
+services:
+    -
+        class: LoyaltyCorp\RequestHandlers\Bridge\PhpStan\ObjectBuilderReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension

--- a/src/Builder/Interfaces/ObjectBuilderInterface.php
+++ b/src/Builder/Interfaces/ObjectBuilderInterface.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Builder\Interfaces;
+
+use LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface;
+
+interface ObjectBuilderInterface
+{
+    /**
+     * Builds a valid Request Object given the supplied json and optional additional
+     * context.
+     *
+     * @param string $objectClass
+     * @param string $json
+     * @param mixed[]|null $context
+     *
+     * @return \LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface
+     */
+    public function build(string $objectClass, string $json, ?array $context = null): RequestObjectInterface;
+
+    /**
+     * Ensures that a Request Object is validated.
+     *
+     * @param \LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface $object
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\RequestValidationException
+     */
+    public function ensureValidated(RequestObjectInterface $object): void;
+}

--- a/src/Builder/Interfaces/ObjectBuilderInterface.php
+++ b/src/Builder/Interfaces/ObjectBuilderInterface.php
@@ -20,6 +20,17 @@ interface ObjectBuilderInterface
     public function build(string $objectClass, string $json, ?array $context = null): RequestObjectInterface;
 
     /**
+     * Used to build a request object with an array of context. Is used if there
+     * is no point to providing JSON and properties are directly provided instead.
+     *
+     * @param string $objectClass
+     * @param mixed[] $context
+     *
+     * @return \LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface
+     */
+    public function buildWithContext(string $objectClass, array $context): RequestObjectInterface;
+
+    /**
      * Ensures that a Request Object is validated.
      *
      * @param \LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface $object

--- a/src/Builder/ObjectBuilder.php
+++ b/src/Builder/ObjectBuilder.php
@@ -89,6 +89,18 @@ final class ObjectBuilder implements ObjectBuilderInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\RequestValidationException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\UnsupportedClassException
+     */
+    public function buildWithContext(string $objectClass, array $context): RequestObjectInterface
+    {
+        return $this->build($objectClass, '{}', $context);
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function ensureValidated(RequestObjectInterface $instance): void
     {

--- a/src/Builder/ObjectBuilder.php
+++ b/src/Builder/ObjectBuilder.php
@@ -1,0 +1,135 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Builder;
+
+use LoyaltyCorp\RequestHandlers\Builder\Interfaces\ObjectBuilderInterface;
+use LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException;
+use LoyaltyCorp\RequestHandlers\Exceptions\UnsupportedClassException;
+use LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface;
+use LoyaltyCorp\RequestHandlers\Serializer\PropertyNormalizer;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final class ObjectBuilder implements ObjectBuilderInterface
+{
+    /**
+     * The group used for pre validation.
+     */
+    private const PREVALIDATE_GROUP = 'PreValidate';
+
+    /**
+     * @var \Symfony\Component\Serializer\SerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * @var \Symfony\Component\Validator\Validator\ValidatorInterface
+     */
+    private $validator;
+
+    /**
+     * Constructor
+     *
+     * @param \Symfony\Component\Serializer\SerializerInterface $serializer
+     * @param \Symfony\Component\Validator\Validator\ValidatorInterface $validator
+     */
+    public function __construct(SerializerInterface $serializer, ValidatorInterface $validator)
+    {
+        $this->serializer = $serializer;
+        $this->validator = $validator;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\RequestValidationException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\UnsupportedClassException
+     */
+    public function build(string $objectClass, string $json, ?array $context = null): RequestObjectInterface
+    {
+        $instance = $this->serializer->deserialize(
+            $json,
+            $objectClass,
+            'json',
+            [
+                PropertyNormalizer::DISABLE_TYPE_ENFORCEMENT => true,
+                PropertyNormalizer::EXTRA_PARAMETERS => $context ?? []
+            ]
+        );
+
+        if (($instance instanceof $objectClass) === false) {
+            throw new MisconfiguredSerializerException(\sprintf(
+                'The serializer returned an object of type "%s" but it is not an instance of "%s"',
+                \get_class($instance),
+                $objectClass
+            ));
+        }
+
+        if (($instance instanceof RequestObjectInterface) === false) {
+            throw new UnsupportedClassException(\sprintf(
+                'The supplied class "%s" is not supported. It must be an instance of "%s"',
+                $objectClass,
+                RequestObjectInterface::class
+            ));
+        }
+
+        /**
+         * @var \LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface $instance
+         *
+         * @see https://youtrack.jetbrains.com/issue/WI-37859 - typehint required until PhpStorm recognises === check
+         */
+
+        $this->ensureValidated($instance);
+
+        return $instance;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function ensureValidated(RequestObjectInterface $instance): void
+    {
+        $violations = $this->validate($instance);
+
+        if ($violations->count() === 0) {
+            return;
+        }
+
+        $exceptionClass = $instance::getExceptionClass();
+
+        throw new $exceptionClass($violations);
+    }
+
+    /**
+     * Validates a request object.
+     *
+     * @param \LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface $instance
+     *
+     * @return \Symfony\Component\Validator\ConstraintViolationList
+     */
+    private function validate(RequestObjectInterface $instance): ConstraintViolationList
+    {
+        /** @var \Symfony\Component\Validator\ConstraintViolationList $violations */
+        $violations = $this->validator->validate(
+            $instance,
+            null,
+            [static::PREVALIDATE_GROUP]
+        );
+
+        if ($violations->count()) {
+            return $violations;
+        }
+
+        // Validate with default and resolved validation groups.
+        $groups = $instance->resolveValidationGroups();
+        $groups[] = 'Default';
+
+        /** @var \Symfony\Component\Validator\ConstraintViolationList $violations */
+        $violations = $this->validator->validate($instance, null, $groups);
+
+        return $violations;
+    }
+}

--- a/src/Exceptions/MisconfiguredSerializerException.php
+++ b/src/Exceptions/MisconfiguredSerializerException.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Exceptions;
+
+use EoneoPay\Utils\Exceptions\RuntimeException;
+
+class MisconfiguredSerializerException extends RuntimeException
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorCode(): int
+    {
+        return 70;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorSubCode(): int
+    {
+        return 1;
+    }
+}

--- a/src/Exceptions/UnsupportedClassException.php
+++ b/src/Exceptions/UnsupportedClassException.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Exceptions;
+
+use EoneoPay\Utils\Exceptions\RuntimeException;
+
+class UnsupportedClassException extends RuntimeException
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorCode(): int
+    {
+        return 60;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorSubCode(): int
+    {
+        return 1;
+    }
+}

--- a/tests/Bridge/Laravel/Providers/ParamConverterProviderTest.php
+++ b/tests/Bridge/Laravel/Providers/ParamConverterProviderTest.php
@@ -7,6 +7,8 @@ use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use EoneoPay\Utils\AnnotationReader;
 use LoyaltyCorp\RequestHandlers\Bridge\Laravel\Providers\ParamConverterProvider;
+use LoyaltyCorp\RequestHandlers\Builder\Interfaces\ObjectBuilderInterface;
+use LoyaltyCorp\RequestHandlers\Builder\ObjectBuilder;
 use LoyaltyCorp\RequestHandlers\Request\DoctrineParamConverter;
 use LoyaltyCorp\RequestHandlers\Request\RequestBodyParamConverter;
 use LoyaltyCorp\RequestHandlers\Serializer\RequestBodySerializer;
@@ -67,6 +69,7 @@ class ParamConverterProviderTest extends TestCase
             LessThanValidator::class => LessThanValidator::class,
             NotEqualToValidator::class => NotEqualToValidator::class,
             NotIdenticalToValidator::class => NotIdenticalToValidator::class,
+            ObjectBuilderInterface::class => ObjectBuilder::class,
             PropertyAccessorInterface::class => PropertyAccessor::class,
             RequestBodyParamConverter::class => RequestBodyParamConverter::class,
             ParamConverterListener::class => ParamConverterListener::class,

--- a/tests/Bridge/PhpStan/ObjectBuilderReturnTypeExtensionTest.php
+++ b/tests/Bridge/PhpStan/ObjectBuilderReturnTypeExtensionTest.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name\FullyQualified;
-use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\Dummy\DummyMethodReflection;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
@@ -19,6 +18,11 @@ use PHPStan\Type\ObjectType;
 use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\PhpStan\ScopeStub;
 use Tests\LoyaltyCorp\RequestHandlers\TestCase;
 
+/**
+ * @covers \LoyaltyCorp\RequestHandlers\Bridge\PhpStan\ObjectBuilderReturnTypeExtension
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) required to test
+ */
 class ObjectBuilderReturnTypeExtensionTest extends TestCase
 {
     /**

--- a/tests/Bridge/PhpStan/ObjectBuilderReturnTypeExtensionTest.php
+++ b/tests/Bridge/PhpStan/ObjectBuilderReturnTypeExtensionTest.php
@@ -1,0 +1,158 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Bridge\PhpStan;
+
+use LoyaltyCorp\RequestHandlers\Bridge\PhpStan\ObjectBuilderReturnTypeExtension;
+use LoyaltyCorp\RequestHandlers\Builder\Interfaces\ObjectBuilderInterface;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name\FullyQualified;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\Dummy\DummyMethodReflection;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\PhpStan\ScopeStub;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+class ObjectBuilderReturnTypeExtensionTest extends TestCase
+{
+    /**
+     * Tests what class the extension supports.
+     *
+     * @return void
+     */
+    public function testSupportedClass(): void
+    {
+        $extension = new ObjectBuilderReturnTypeExtension();
+
+        static::assertSame(ObjectBuilderInterface::class, $extension->getClass());
+    }
+
+    /**
+     * Tests extension supports build method
+     *
+     * @return void
+     */
+    public function testSupportedMethodBuild(): void
+    {
+        $extension = new ObjectBuilderReturnTypeExtension();
+
+        $method = new DummyMethodReflection('build');
+
+        static::assertTrue($extension->isMethodSupported($method));
+    }
+
+    /**
+     * Tests extension supports buildWithContext method
+     *
+     * @return void
+     */
+    public function testSupportedMethodBuildWithContext(): void
+    {
+        $extension = new ObjectBuilderReturnTypeExtension();
+
+        $method = new DummyMethodReflection('buildWithContext');
+
+        static::assertTrue($extension->isMethodSupported($method));
+    }
+
+    /**
+     * Tests that the getTypeFromMethodCall method returns the expected ObjectType
+     * from the first argument.
+     *
+     * @return void
+     *
+     * @throws \PHPStan\Analyser\UndefinedVariableException
+     * @throws \PHPStan\Broker\ClassAutoloadingException
+     * @throws \PHPStan\Broker\ClassNotFoundException
+     * @throws \PHPStan\Broker\FunctionNotFoundException
+     * @throws \PHPStan\Reflection\MissingConstantFromReflectionException
+     * @throws \PHPStan\Reflection\MissingMethodFromReflectionException
+     * @throws \PHPStan\Reflection\MissingPropertyFromReflectionException
+     * @throws \PHPStan\ShouldNotHappenException
+     */
+    public function testGetTypeFromMethodCall(): void
+    {
+        $extension = new ObjectBuilderReturnTypeExtension();
+
+        $method = new DummyMethodReflection('build');
+        $call = new MethodCall(
+            new MethodCall(
+                new Variable('this'),
+                'getObjectBuilder'
+            ),
+            'buildWithContext',
+            [
+                new Arg(
+                    new ClassConstFetch(
+                        new FullyQualified('stdClass'),
+                        'name'
+                    )
+                )
+            ]
+        );
+        $type = new ConstantStringType('stdClass');
+        $scope = new ScopeStub($type);
+
+        $expected = new ObjectType('stdClass');
+
+        $result = $extension->getTypeFromMethodCall(
+            $method,
+            $call,
+            $scope
+        );
+
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Tests that the getTypeFromMethodCall method returns mixed when the first
+     * argument is untyped.
+     *
+     * @return void
+     *
+     * @throws \PHPStan\Analyser\UndefinedVariableException
+     * @throws \PHPStan\Broker\ClassAutoloadingException
+     * @throws \PHPStan\Broker\ClassNotFoundException
+     * @throws \PHPStan\Broker\FunctionNotFoundException
+     * @throws \PHPStan\Reflection\MissingConstantFromReflectionException
+     * @throws \PHPStan\Reflection\MissingMethodFromReflectionException
+     * @throws \PHPStan\Reflection\MissingPropertyFromReflectionException
+     * @throws \PHPStan\ShouldNotHappenException
+     */
+    public function testGetTypeFromMethodCallUntypedParam(): void
+    {
+        $extension = new ObjectBuilderReturnTypeExtension();
+
+        $method = new DummyMethodReflection('build');
+        $call = new MethodCall(
+            new MethodCall(
+                new Variable('this'),
+                'getObjectBuilder'
+            ),
+            'buildWithContext',
+            [
+                new Arg(
+                    new Variable('variable')
+                )
+            ]
+        );
+        $type = new ConstantIntegerType(5);
+        $scope = new ScopeStub($type);
+
+        $expected = new MixedType();
+
+        $result = $extension->getTypeFromMethodCall(
+            $method,
+            $call,
+            $scope
+        );
+
+        static::assertEquals($expected, $result);
+    }
+}

--- a/tests/Builder/ObjectBuilderTest.php
+++ b/tests/Builder/ObjectBuilderTest.php
@@ -44,6 +44,28 @@ class ObjectBuilderTest extends TestCase
     }
 
     /**
+     * Tests the buildWithContext happy path.
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\RequestValidationException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\UnsupportedClassException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException
+     */
+    public function testBuildWithContext(): void
+    {
+        $expected = new TestRequest();
+
+        $serializer = new SerializerStub($expected);
+        $validator = new ValidatorStub();
+        $builder = $this->getBuilder($serializer, $validator);
+
+        $result = $builder->buildWithContext(TestRequest::class, []);
+
+        static::assertSame($expected, $result);
+    }
+
+    /**
      * Tests the build happy path.
      *
      * @return void

--- a/tests/Builder/ObjectBuilderTest.php
+++ b/tests/Builder/ObjectBuilderTest.php
@@ -22,7 +22,7 @@ use Tests\LoyaltyCorp\RequestHandlers\TestCase;
 class ObjectBuilderTest extends TestCase
 {
     /**
-     * Tests the build happy path.
+     * Tests that build returns the object the serializer returned.
      *
      * @return void
      *
@@ -44,7 +44,7 @@ class ObjectBuilderTest extends TestCase
     }
 
     /**
-     * Tests the buildWithContext happy path.
+     * Tests the buildWithContext returns the expected.
      *
      * @return void
      *
@@ -175,6 +175,7 @@ class ObjectBuilderTest extends TestCase
         $request = new TestRequest();
 
         $validator = new ValidatorStub([[
+            // Violations in PreValidate
             new ConstraintViolation(
                 'Message',
                 'Message',
@@ -209,45 +210,4 @@ class ObjectBuilderTest extends TestCase
             $validator ?? new ValidatorStub()
         );
     }
-
-//    /**
-//     * Tests PreValidate runs before primary validate
-//     *
-//     * @return void
-//     */
-//    public function testHandleViolationInPreValidate(): void
-//    {
-//        $violation1 = new ConstraintViolation('PreValidate', null, [], null, null, null);
-//        $violation2 = new ConstraintViolation('StandardValidation', null, [], null, null, null);
-//        $validator = new ValidatorStub([
-//            // PreValidate violation
-//            [$violation1],
-//            // Violation in normal validation
-//            [$violation2]
-//        ]);
-//
-//        $middleware = new ValidatingMiddleware($validator);
-//
-//        $request = new Request();
-//        $request->setRouteResolver(static function () {
-//            return [null, null, [
-//                'object' => new RequestObjectStub()
-//            ]];
-//        });
-//
-//        $next = static function () {
-//            return 'hello';
-//        };
-//
-//        try {
-//            $middleware->handle($request, $next);
-//        } catch (RequestValidationException $exception) {
-//            static::assertContains($violation1, $exception->getViolations());
-//            static::assertNotContains($violation2, $exception->getViolations());
-//
-//            return;
-//        }
-//
-//        static::fail('Exception was not thrown');
-//    }
 }

--- a/tests/Builder/ObjectBuilderTest.php
+++ b/tests/Builder/ObjectBuilderTest.php
@@ -1,0 +1,231 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Builder;
+
+use LoyaltyCorp\RequestHandlers\Builder\ObjectBuilder;
+use LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException;
+use LoyaltyCorp\RequestHandlers\Exceptions\RequestValidationException;
+use LoyaltyCorp\RequestHandlers\Exceptions\UnsupportedClassException;
+use stdClass;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Tests\LoyaltyCorp\RequestHandlers\Fixtures\TestRequest;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Symfony\SerializerStub;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Symfony\Validator\ValidatorStub;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\RequestHandlers\Builder\ObjectBuilder
+ */
+class ObjectBuilderTest extends TestCase
+{
+    /**
+     * Tests the build happy path.
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\RequestValidationException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\UnsupportedClassException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException
+     */
+    public function testBuild(): void
+    {
+        $expected = new TestRequest();
+
+        $serializer = new SerializerStub($expected);
+        $validator = new ValidatorStub();
+        $builder = $this->getBuilder($serializer, $validator);
+
+        $result = $builder->build(TestRequest::class, '');
+
+        static::assertSame($expected, $result);
+    }
+
+    /**
+     * Tests the build happy path.
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\RequestValidationException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\UnsupportedClassException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException
+     */
+    public function testBuildWrongObject(): void
+    {
+        $serializer = new SerializerStub(new stdClass());
+        $validator = new ValidatorStub();
+        $builder = $this->getBuilder($serializer, $validator);
+
+        $this->expectException(MisconfiguredSerializerException::class);
+        $this->expectExceptionMessage(
+            'The serializer returned an object of type "stdClass" but it is not an instance of "Tests\LoyaltyCorp\RequestHandlers\Fixtures\TestRequest"' // phpcs:ignore
+        );
+
+        $builder->build(TestRequest::class, '');
+    }
+
+    /**
+     * Tests the build happy path.
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\RequestValidationException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\UnsupportedClassException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException
+     */
+    public function testBuildNotRequestObject(): void
+    {
+        $serializer = new SerializerStub(new stdClass());
+        $validator = new ValidatorStub();
+        $builder = $this->getBuilder($serializer, $validator);
+
+        $this->expectException(UnsupportedClassException::class);
+        $this->expectExceptionMessage(
+            'The supplied class "stdClass" is not supported. It must be an instance of "LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface"' // phpcs:ignore
+        );
+
+        $builder->build(stdClass::class, '');
+    }
+
+    /**
+     * Tests that ensure validated does not throw when the object is valid.
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\RequestValidationException
+     */
+    public function testEnsureValidated(): void
+    {
+        $request = new TestRequest();
+
+        $validator = new ValidatorStub();
+        $builder = $this->getBuilder(null, $validator);
+
+        $builder->ensureValidated($request);
+
+        // No exception was thrown.
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * Tests that ensure validated throws when the object is invalid in PreValidate.
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\RequestValidationException
+     */
+    public function testEnsureValidatedThrows(): void
+    {
+        $request = new TestRequest();
+
+        $validator = new ValidatorStub([
+            [], // PreValidate
+            [ // Primary Validate
+                new ConstraintViolation(
+                    'Message',
+                    'Message',
+                    [],
+                    '',
+                    '',
+                    ''
+                )
+            ]
+        ]);
+
+        $builder = $this->getBuilder(null, $validator);
+
+        $this->expectException(RequestValidationException::class);
+
+        $builder->ensureValidated($request);
+    }
+
+    /**
+     * Tests that ensure validated throws when the object is invalid in PreValidate.
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\RequestValidationException
+     */
+    public function testEnsureValidatedThrowsPreValidate(): void
+    {
+        $request = new TestRequest();
+
+        $validator = new ValidatorStub([[
+            new ConstraintViolation(
+                'Message',
+                'Message',
+                [],
+                '',
+                '',
+                ''
+            )
+        ]]);
+
+        $builder = $this->getBuilder(null, $validator);
+
+        $this->expectException(RequestValidationException::class);
+
+        $builder->ensureValidated($request);
+    }
+
+    /**
+     * Gets the builder under test.
+     *
+     * @param \Symfony\Component\Serializer\SerializerInterface|null $serializer
+     * @param \Symfony\Component\Validator\Validator\ValidatorInterface|null $validator
+     *
+     * @return \LoyaltyCorp\RequestHandlers\Builder\ObjectBuilder
+     */
+    private function getBuilder(
+        ?SerializerInterface $serializer = null,
+        ?ValidatorInterface $validator = null
+    ): ObjectBuilder {
+        return new ObjectBuilder(
+            $serializer ?? new SerializerStub(),
+            $validator ?? new ValidatorStub()
+        );
+    }
+
+//    /**
+//     * Tests PreValidate runs before primary validate
+//     *
+//     * @return void
+//     */
+//    public function testHandleViolationInPreValidate(): void
+//    {
+//        $violation1 = new ConstraintViolation('PreValidate', null, [], null, null, null);
+//        $violation2 = new ConstraintViolation('StandardValidation', null, [], null, null, null);
+//        $validator = new ValidatorStub([
+//            // PreValidate violation
+//            [$violation1],
+//            // Violation in normal validation
+//            [$violation2]
+//        ]);
+//
+//        $middleware = new ValidatingMiddleware($validator);
+//
+//        $request = new Request();
+//        $request->setRouteResolver(static function () {
+//            return [null, null, [
+//                'object' => new RequestObjectStub()
+//            ]];
+//        });
+//
+//        $next = static function () {
+//            return 'hello';
+//        };
+//
+//        try {
+//            $middleware->handle($request, $next);
+//        } catch (RequestValidationException $exception) {
+//            static::assertContains($violation1, $exception->getViolations());
+//            static::assertNotContains($violation2, $exception->getViolations());
+//
+//            return;
+//        }
+//
+//        static::fail('Exception was not thrown');
+//    }
+}

--- a/tests/Exceptions/MisconfiguredSerializerExceptionTest.php
+++ b/tests/Exceptions/MisconfiguredSerializerExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Exceptions;
+
+use LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException
+ */
+class MisconfiguredSerializerExceptionTest extends TestCase
+{
+    /**
+     * Tests methods on DoctrineDenormalizerMappingException
+     *
+     * @return void
+     */
+    public function testExceptionMethods(): void
+    {
+        $exception = new MisconfiguredSerializerException();
+
+        self::assertSame(1, $exception->getErrorSubCode());
+        self::assertSame(70, $exception->getErrorCode());
+        self::assertSame(500, $exception->getStatusCode());
+    }
+}

--- a/tests/Exceptions/UnsupportedClassExceptionTest.php
+++ b/tests/Exceptions/UnsupportedClassExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Exceptions;
+
+use LoyaltyCorp\RequestHandlers\Exceptions\UnsupportedClassException;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\RequestHandlers\Exceptions\UnsupportedClassException
+ */
+class UnsupportedClassExceptionTest extends TestCase
+{
+    /**
+     * Tests methods on DoctrineDenormalizerMappingException
+     *
+     * @return void
+     */
+    public function testExceptionMethods(): void
+    {
+        $exception = new UnsupportedClassException();
+
+        self::assertSame(1, $exception->getErrorSubCode());
+        self::assertSame(60, $exception->getErrorCode());
+        self::assertSame(500, $exception->getStatusCode());
+    }
+}

--- a/tests/Fixtures/TestRequest.php
+++ b/tests/Fixtures/TestRequest.php
@@ -1,10 +1,11 @@
 <?php
 declare(strict_types=1);
 
-namespace Tests\LoyaltyCorp\RequestHandlers\TestHelper\Fixtures;
+namespace Tests\LoyaltyCorp\RequestHandlers\Fixtures;
 
 use LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface;
 use Symfony\Component\Validator\Constraints as Assert;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Exceptions\RequestValidationExceptionStub;
 
 class TestRequest implements RequestObjectInterface
 {
@@ -40,7 +41,7 @@ class TestRequest implements RequestObjectInterface
      */
     public static function getExceptionClass(): string
     {
-        return '';
+        return RequestValidationExceptionStub::class;
     }
 
     /**

--- a/tests/Stubs/Builder/ObjectBuilderStub.php
+++ b/tests/Stubs/Builder/ObjectBuilderStub.php
@@ -47,6 +47,14 @@ class ObjectBuilderStub implements ObjectBuilderInterface
     /**
      * {@inheritdoc}
      */
+    public function buildWithContext(string $objectClass, array $context): RequestObjectInterface
+    {
+        return $this->build($objectClass, '{}', $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function ensureValidated(RequestObjectInterface $object): void
     {
         $next = \array_shift($this->validated);

--- a/tests/Stubs/Builder/ObjectBuilderStub.php
+++ b/tests/Stubs/Builder/ObjectBuilderStub.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Stubs\Builder;
+
+use LoyaltyCorp\RequestHandlers\Builder\Interfaces\ObjectBuilderInterface;
+use LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Exceptions\RequestValidationExceptionStub;
+
+class ObjectBuilderStub implements ObjectBuilderInterface
+{
+    /**
+     * Objects to return when build is called.
+     *
+     * @var \LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface[]
+     */
+    private $objects;
+
+    /**
+     * If the objects passed to ensure are valid.
+     *
+     * @var bool[]
+     */
+    private $validated;
+
+    /**
+     * Constructor
+     *
+     * @param \LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface[]|null $objects
+     * @param bool[]|null $validated
+     */
+    public function __construct(?array $objects = null, ?array $validated = null)
+    {
+        $this->objects = $objects ?? [];
+        $this->validated = $validated ?? [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function build(string $objectClass, string $json, ?array $context = null): RequestObjectInterface
+    {
+        return \array_shift($this->objects) ?: new $objectClass();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function ensureValidated(RequestObjectInterface $object): void
+    {
+        $next = \array_shift($this->validated);
+
+        if ($next === true) {
+            return;
+        }
+
+        throw new RequestValidationExceptionStub(new ConstraintViolationList());
+    }
+}

--- a/tests/Stubs/Vendor/PhpStan/ScopeStub.php
+++ b/tests/Stubs/Vendor/PhpStan/ScopeStub.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\PhpStan;
+
+use PhpParser\Node\Expr;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\Type;
+
+class ScopeStub extends Scope
+{
+    /**
+     * @var \PHPStan\Type\Type
+     */
+    private $returnType;
+
+    /**
+     * Intentionally overridden.
+     *
+     * @noinspection PhpMissingParentConstructorInspection
+     *
+     * @param \PHPStan\Type\Type $returnType
+     */
+    public function __construct(Type $returnType)
+    {
+        $this->returnType = $returnType;
+    }
+
+    /**
+     * @noinspection PhpMissingParentCallCommonInspection
+     *
+     * {@inheritdoc}
+     */
+    public function getType(Expr $node): Type
+    {
+        return $this->returnType;
+    }
+}

--- a/tests/TestHelper/RequestObjectTestHelperTest.php
+++ b/tests/TestHelper/RequestObjectTestHelperTest.php
@@ -9,11 +9,11 @@ use LoyaltyCorp\RequestHandlers\TestHelper\RequestObjectTestHelper;
 use RuntimeException;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Tests\LoyaltyCorp\RequestHandlers\Fixtures\TestRequest;
 use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Illuminate\Contracts\Foundation\ApplicationStub;
 use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Symfony\SerializerStub;
 use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Symfony\Validator\ValidatorStub;
 use Tests\LoyaltyCorp\RequestHandlers\TestCase;
-use Tests\LoyaltyCorp\RequestHandlers\Fixtures\TestRequest;
 
 /**
  * @covers \LoyaltyCorp\RequestHandlers\TestHelper\RequestObjectTestHelper

--- a/tests/TestHelper/RequestObjectTestHelperTest.php
+++ b/tests/TestHelper/RequestObjectTestHelperTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Tests\LoyaltyCorp\RequestHandlers\TestHelper;
 
+use LoyaltyCorp\RequestHandlers\Builder\ObjectBuilder;
 use LoyaltyCorp\RequestHandlers\TestHelper\Exceptions\ValidationFailedException;
 use LoyaltyCorp\RequestHandlers\TestHelper\RequestObjectTestHelper;
 use RuntimeException;
@@ -12,7 +13,7 @@ use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Illuminate\Contracts\Foundati
 use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Symfony\SerializerStub;
 use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Symfony\Validator\ValidatorStub;
 use Tests\LoyaltyCorp\RequestHandlers\TestCase;
-use Tests\LoyaltyCorp\RequestHandlers\TestHelper\Fixtures\TestRequest;
+use Tests\LoyaltyCorp\RequestHandlers\Fixtures\TestRequest;
 
 /**
  * @covers \LoyaltyCorp\RequestHandlers\TestHelper\RequestObjectTestHelper
@@ -150,6 +151,9 @@ class RequestObjectTestHelperTest extends TestCase
         $validator = new ValidatorStub($violations);
         $container->instance(ValidatorInterface::class, $validator);
 
-        return new RequestObjectTestHelper($container);
+        return new RequestObjectTestHelper(
+            new ObjectBuilder($serializer, $validator),
+            $serializer
+        );
     }
 }


### PR DESCRIPTION
This is a first pass PR to add an ObjectBuilder service to request handlers.

It provides a single point where valid request objects can be created, and is the first step towards validated objects for service consumption.