### PR TITLE
PYMT-1048: Add scalar normalization

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -27,9 +27,6 @@ parameters:
             message: '#Method LoyaltyCorp\\RequestHandlers\\Serializer\\DoctrineDenormalizer::denormalize\(\) should return object but returns null\.#'
             path: src/Serializer/DoctrineDenormalizer.php
         -
-            message: '#Method LoyaltyCorp\\RequestHandlers\\Serializer\\DoctrineDenormalizer::denormalize\(\) should return object but returns object\|string\.#'
-            path: src/Serializer/DoctrineDenormalizer.php
-        -
             message: '#Method LoyaltyCorp\\RequestHandlers\\Serializer\\DoctrineDenormalizer::denormalize\(\) should return object but returns object\|null\.#'
             path: src/Serializer/DoctrineDenormalizer.php
         -
@@ -55,6 +52,9 @@ parameters:
             path: tests/Integration/RequestIntegrationTest.php
         -
             message: '#Call to static method PHPUnit\\Framework\\Assert::assertSame\(\) with .purple. and object will always evaluate to false\.#'
+            path: tests/Serializer/DoctrineDenormalizerTest.php
+        -
+            message: '#Call to static method PHPUnit\\Framework\\Assert::assertSame\(\) with .somevalue. and object will always evaluate to false\.#'
             path: tests/Serializer/DoctrineDenormalizerTest.php
         -
             message: '#Result of && is always false\.#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -27,6 +27,9 @@ parameters:
             message: '#Method LoyaltyCorp\\RequestHandlers\\Serializer\\DoctrineDenormalizer::denormalize\(\) should return object but returns null\.#'
             path: src/Serializer/DoctrineDenormalizer.php
         -
+            message: '#Method LoyaltyCorp\\RequestHandlers\\Serializer\\DoctrineDenormalizer::denormalize\(\) should return object but returns object\|string\.#'
+            path: src/Serializer/DoctrineDenormalizer.php
+        -
             message: '#Method LoyaltyCorp\\RequestHandlers\\Serializer\\DoctrineDenormalizer::denormalize\(\) should return object but returns object\|null\.#'
             path: src/Serializer/DoctrineDenormalizer.php
         -

--- a/src/Serializer/DoctrineDenormalizer.php
+++ b/src/Serializer/DoctrineDenormalizer.php
@@ -63,7 +63,12 @@ final class DoctrineDenormalizer implements DenormalizerInterface
 
             return $data;
         }
-
+        if (\is_string($data) === true) {
+            $result = $this->findOneBy($class, ['externalId' => $data]);
+            if ($result !== null) {
+                return $result;
+            }
+        }
         if ($data === null || \is_array($data) === false) {
             // If the data is null or we didnt get an array, just return the data
             // so that the object can be validated with the user supplied data.

--- a/src/Serializer/DoctrineDenormalizer.php
+++ b/src/Serializer/DoctrineDenormalizer.php
@@ -136,7 +136,7 @@ final class DoctrineDenormalizer implements DenormalizerInterface
      *
      * @param string $class Class name
      *
-     * @return mixed[]
+     * @return string[] Array where key is the Entity ID field, value is the key in the JSON request.
      *
      * @throws \LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerMappingException
      */

--- a/src/Serializer/DoctrineDenormalizer.php
+++ b/src/Serializer/DoctrineDenormalizer.php
@@ -56,23 +56,9 @@ final class DoctrineDenormalizer implements DenormalizerInterface
      */
     public function denormalize($data, $class, $format = null, ?array $context = null)
     {
-        if ($data instanceof $class === true) {
-            // In some circumstances we're going to end up with $data being an object
-            // already, especially when we're using ->denormalize() specifically instead
-            // of deserialize
-
-            return $data;
-        }
-        if (\is_string($data) || \is_int($data) === true) {
-            $key = \array_key_first($this->getClassLookupKey($class));
-            $result = $this->findOneBy($class, [$key => $data]);
-            return $result ?? $data;
-        }
-        if ($data === null || \is_array($data) === false) {
-            // If the data is null or we didnt get an array, just return the data
-            // so that the object can be validated with the user supplied data.
-
-            return $data;
+        // If the data isn't an array, hand off to see if we can still discover the entity from it.
+        if (\is_array($data) === false) {
+            return $this->denormalizeNonArray($data, $class);
         }
 
         // entity criteria
@@ -113,6 +99,32 @@ final class DoctrineDenormalizer implements DenormalizerInterface
         }
 
         return $manager->getMetadataFactory()->isTransient($type) === false;
+    }
+
+    /**
+     * Attempts to denormalize a string or integer into an Entity
+     *
+     * @param mixed  $data    Data to restore
+     * @param string $class   The expected class to instantiate
+     *
+     * @return mixed
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerMappingException
+     */
+    private function denormalizeNonArray($data, string $class)
+    {
+        if (\is_string($data) !== true && \is_int($data) !== true) {
+            return $data;
+        }
+        $keys = $this->getClassLookupKey($class);
+        // If there's more than a single key, and the defined default, we've got a composite key, which we can't
+        // handle with a single scalar value.
+        if (\count($keys) > 2) {
+            return $data;
+        }
+        $key = \array_key_first($keys);
+        $result = $this->findOneBy($class, [$key => $data]);
+        return $result ?? $data;
     }
 
     /**

--- a/src/Serializer/DoctrineDenormalizer.php
+++ b/src/Serializer/DoctrineDenormalizer.php
@@ -66,9 +66,7 @@ final class DoctrineDenormalizer implements DenormalizerInterface
         if (\is_string($data) === true) {
             $key = \array_key_first($this->getClassLookupKey($class));
             $result = $this->findOneBy($class, [$key => $data]);
-            if ($result !== null) {
-                return $result;
-            }
+            return $result ?? $data;
         }
         if ($data === null || \is_array($data) === false) {
             // If the data is null or we didnt get an array, just return the data

--- a/src/Serializer/DoctrineDenormalizer.php
+++ b/src/Serializer/DoctrineDenormalizer.php
@@ -64,7 +64,8 @@ final class DoctrineDenormalizer implements DenormalizerInterface
             return $data;
         }
         if (\is_string($data) === true) {
-            $result = $this->findOneBy($class, ['externalId' => $data]);
+            $key = \array_key_first($this->getClassLookupKey($class));
+            $result = $this->findOneBy($class, [$key => $data]);
             if ($result !== null) {
                 return $result;
             }
@@ -156,6 +157,6 @@ final class DoctrineDenormalizer implements DenormalizerInterface
             throw new DoctrineDenormalizerMappingException('Mis-configured class-key mappings in denormalizer.');
         }
 
-        return \array_merge($default, $keyMap);
+        return \array_merge($keyMap, $default);
     }
 }

--- a/src/Serializer/DoctrineDenormalizer.php
+++ b/src/Serializer/DoctrineDenormalizer.php
@@ -63,7 +63,7 @@ final class DoctrineDenormalizer implements DenormalizerInterface
 
             return $data;
         }
-        if (\is_string($data) === true) {
+        if (\is_string($data) || \is_int($data) === true) {
             $key = \array_key_first($this->getClassLookupKey($class));
             $result = $this->findOneBy($class, [$key => $data]);
             return $result ?? $data;

--- a/tests/Serializer/DoctrineDenormalizerTest.php
+++ b/tests/Serializer/DoctrineDenormalizerTest.php
@@ -62,25 +62,30 @@ class DoctrineDenormalizerTest extends TestCase
      * @throws \LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerMappingException
      * @throws \Symfony\Component\Serializer\Exception\ExceptionInterface
      */
-    public function testDenormalizeStrings(): void
+    public function testDenormalizeScalarMatchingId(): void
     {
         $entity = new stdClass();
 
         $repository = $this->createMock(ObjectRepository::class);
-        $repository->expects(self::once())
+        $repository->expects(self::exactly(2))
             ->method('findOneBy')
             ->willReturnMap([
-                [['externalId' => 'entityId'], $entity]
+                [['externalId' => 'entityId'], $entity],
+                [['externalId' => 789], $entity]
             ]);
 
         $registry = $this->createMock(ManagerRegistry::class);
-        $registry->expects(self::once())
+        $registry->expects(self::exactly(2))
             ->method('getRepository')
             ->with('EntityClass')
             ->willReturn($repository);
 
         $denormalizer = new DoctrineDenormalizer($registry);
         $result = $denormalizer->denormalize('entityId', 'EntityClass');
+        self::assertSame($entity, $result);
+
+        $denormalizer = new DoctrineDenormalizer($registry);
+        $result = $denormalizer->denormalize(789, 'EntityClass');
         self::assertSame($entity, $result);
     }
 
@@ -152,14 +157,14 @@ class DoctrineDenormalizerTest extends TestCase
     }
 
     /**
-     * Tests denormalize scalar
+     * Tests denormalize scalar that doesn't match anything.
      *
      * @return void
      *
      * @throws \LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerMappingException
      * @throws \Symfony\Component\Serializer\Exception\ExceptionInterface
      */
-    public function testDenormalizeScalar(): void
+    public function testDenormalizeScalarNonMatch(): void
     {
         $repository = $this->createMock(ObjectRepository::class);
         $registry = $this->createMock(ManagerRegistry::class);

--- a/tests/Serializer/DoctrineDenormalizerTest.php
+++ b/tests/Serializer/DoctrineDenormalizerTest.php
@@ -114,9 +114,13 @@ class DoctrineDenormalizerTest extends TestCase
             ->with('EntityClass')
             ->willReturn($repository);
 
-        $denormalizer = new DoctrineDenormalizer($registry, ['EntityClass' => ['customId' => 'xxx', 'yyy' => 'zzz']]);
+        $denormalizer = new DoctrineDenormalizer($registry, ['EntityClass' => ['customId' => 'xxx']]);
         $result = $denormalizer->denormalize('entityIdValue', 'EntityClass');
         self::assertSame($entity, $result);
+
+        $denormalizer = new DoctrineDenormalizer($registry, ['EntityClass' => ['abc' => 'xxx', 'yyy' => 'zzz']]);
+        $result = $denormalizer->denormalize('somevalue', 'EntityClass');
+        self::assertSame('somevalue', $result);
     }
 
     /**


### PR DESCRIPTION
This adds the ability for Request objects to look up something by just a string.

The request object will look for `externalID` if a custom ID map is not supplied. If one is supplied, it will use the first field available.

Please do not change ticket to done when this merges.