### PR TITLE
Add RequestObjectTestHelper to PHPStan

### DIFF
--- a/src/Bridge/PhpStan/AbstractFactoryReturnTypeExtension.php
+++ b/src/Bridge/PhpStan/AbstractFactoryReturnTypeExtension.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Bridge\PhpStan;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+abstract class AbstractFactoryReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \PHPStan\Analyser\UndefinedVariableException
+     * @throws \PHPStan\Broker\ClassAutoloadingException
+     * @throws \PHPStan\Broker\ClassNotFoundException
+     * @throws \PHPStan\Broker\FunctionNotFoundException
+     * @throws \PHPStan\Reflection\MissingConstantFromReflectionException
+     * @throws \PHPStan\Reflection\MissingMethodFromReflectionException
+     * @throws \PHPStan\Reflection\MissingPropertyFromReflectionException
+     * @throws \PHPStan\ShouldNotHappenException
+     */
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
+        $argType = $scope->getType($methodCall->args[0]->value);
+        if ($argType instanceof ConstantStringType === false) {
+            return new MixedType();
+        }
+
+        return new ObjectType($argType->getValue());
+    }
+}

--- a/src/Bridge/PhpStan/RequestObjectTestHelperReturnTypeExtension.php
+++ b/src/Bridge/PhpStan/RequestObjectTestHelperReturnTypeExtension.php
@@ -3,20 +3,20 @@ declare(strict_types=1);
 
 namespace LoyaltyCorp\RequestHandlers\Bridge\PhpStan;
 
-use LoyaltyCorp\RequestHandlers\Builder\Interfaces\ObjectBuilderInterface;
+use LoyaltyCorp\RequestHandlers\TestHelper\RequestObjectTestHelper;
 use PHPStan\Reflection\MethodReflection;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Coupling required due to PHPStan design
  */
-class ObjectBuilderReturnTypeExtension extends AbstractFactoryReturnTypeExtension
+class RequestObjectTestHelperReturnTypeExtension extends AbstractFactoryReturnTypeExtension
 {
     /**
      * {@inheritdoc}
      */
     public function getClass(): string
     {
-        return ObjectBuilderInterface::class;
+        return RequestObjectTestHelper::class;
     }
 
     /**
@@ -24,7 +24,8 @@ class ObjectBuilderReturnTypeExtension extends AbstractFactoryReturnTypeExtensio
      */
     public function isMethodSupported(MethodReflection $methodReflection): bool
     {
-        return $methodReflection->getName() === 'build' ||
-            $methodReflection->getName() === 'buildWithContext';
+        return $methodReflection->getName() === 'buildFailingRequest' ||
+            $methodReflection->getName() === 'buildUnvalidatedRequest' ||
+            $methodReflection->getName() === 'buildValidatedRequest';
     }
 }

--- a/src/Bridge/PhpStan/extension.neon
+++ b/src/Bridge/PhpStan/extension.neon
@@ -3,3 +3,7 @@ services:
         class: LoyaltyCorp\RequestHandlers\Bridge\PhpStan\ObjectBuilderReturnTypeExtension
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
+    -
+        class: LoyaltyCorp\RequestHandlers\Bridge\PhpStan\RequestObjectTestHelperReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension

--- a/tests/Bridge/PhpStan/AbstractFactoryReturnTypeExtensionTest.php
+++ b/tests/Bridge/PhpStan/AbstractFactoryReturnTypeExtensionTest.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Bridge\PhpStan;
+
+use LoyaltyCorp\RequestHandlers\Bridge\PhpStan\ObjectBuilderReturnTypeExtension;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name\FullyQualified;
+use PHPStan\Reflection\Dummy\DummyMethodReflection;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\PhpStan\ScopeStub;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\RequestHandlers\Bridge\PhpStan\AbstractFactoryReturnTypeExtension
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) required to test
+ */
+class AbstractFactoryReturnTypeExtensionTest extends TestCase
+{
+    /**
+     * Tests that the getTypeFromMethodCall method returns the expected ObjectType
+     * from the first argument.
+     *
+     * @return void
+     *
+     * @throws \PHPStan\Analyser\UndefinedVariableException
+     * @throws \PHPStan\Broker\ClassAutoloadingException
+     * @throws \PHPStan\Broker\ClassNotFoundException
+     * @throws \PHPStan\Broker\FunctionNotFoundException
+     * @throws \PHPStan\Reflection\MissingConstantFromReflectionException
+     * @throws \PHPStan\Reflection\MissingMethodFromReflectionException
+     * @throws \PHPStan\Reflection\MissingPropertyFromReflectionException
+     * @throws \PHPStan\ShouldNotHappenException
+     */
+    public function testGetTypeFromMethodCall(): void
+    {
+        $extension = new ObjectBuilderReturnTypeExtension();
+
+        $method = new DummyMethodReflection('build');
+        $call = new MethodCall(
+            new MethodCall(
+                new Variable('this'),
+                'getObjectBuilder'
+            ),
+            'buildWithContext',
+            [
+                new Arg(
+                    new ClassConstFetch(
+                        new FullyQualified('stdClass'),
+                        'name'
+                    )
+                )
+            ]
+        );
+        $type = new ConstantStringType('stdClass');
+        $scope = new ScopeStub($type);
+
+        $expected = new ObjectType('stdClass');
+
+        $result = $extension->getTypeFromMethodCall(
+            $method,
+            $call,
+            $scope
+        );
+
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Tests that the getTypeFromMethodCall method returns mixed when the first
+     * argument is untyped.
+     *
+     * @return void
+     *
+     * @throws \PHPStan\Analyser\UndefinedVariableException
+     * @throws \PHPStan\Broker\ClassAutoloadingException
+     * @throws \PHPStan\Broker\ClassNotFoundException
+     * @throws \PHPStan\Broker\FunctionNotFoundException
+     * @throws \PHPStan\Reflection\MissingConstantFromReflectionException
+     * @throws \PHPStan\Reflection\MissingMethodFromReflectionException
+     * @throws \PHPStan\Reflection\MissingPropertyFromReflectionException
+     * @throws \PHPStan\ShouldNotHappenException
+     */
+    public function testGetTypeFromMethodCallUntypedParam(): void
+    {
+        $extension = new ObjectBuilderReturnTypeExtension();
+
+        $method = new DummyMethodReflection('build');
+        $call = new MethodCall(
+            new MethodCall(
+                new Variable('this'),
+                'getObjectBuilder'
+            ),
+            'buildWithContext',
+            [
+                new Arg(
+                    new Variable('variable')
+                )
+            ]
+        );
+        $type = new ConstantIntegerType(5);
+        $scope = new ScopeStub($type);
+
+        $expected = new MixedType();
+
+        $result = $extension->getTypeFromMethodCall(
+            $method,
+            $call,
+            $scope
+        );
+
+        static::assertEquals($expected, $result);
+    }
+}

--- a/tests/Bridge/PhpStan/ObjectBuilderReturnTypeExtensionTest.php
+++ b/tests/Bridge/PhpStan/ObjectBuilderReturnTypeExtensionTest.php
@@ -5,23 +5,11 @@ namespace Tests\LoyaltyCorp\RequestHandlers\Bridge\PhpStan;
 
 use LoyaltyCorp\RequestHandlers\Bridge\PhpStan\ObjectBuilderReturnTypeExtension;
 use LoyaltyCorp\RequestHandlers\Builder\Interfaces\ObjectBuilderInterface;
-use PhpParser\Node\Arg;
-use PhpParser\Node\Expr\ClassConstFetch;
-use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Name\FullyQualified;
 use PHPStan\Reflection\Dummy\DummyMethodReflection;
-use PHPStan\Type\Constant\ConstantIntegerType;
-use PHPStan\Type\Constant\ConstantStringType;
-use PHPStan\Type\MixedType;
-use PHPStan\Type\ObjectType;
-use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\PhpStan\ScopeStub;
 use Tests\LoyaltyCorp\RequestHandlers\TestCase;
 
 /**
  * @covers \LoyaltyCorp\RequestHandlers\Bridge\PhpStan\ObjectBuilderReturnTypeExtension
- *
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects) required to test
  */
 class ObjectBuilderReturnTypeExtensionTest extends TestCase
 {
@@ -63,100 +51,5 @@ class ObjectBuilderReturnTypeExtensionTest extends TestCase
         $method = new DummyMethodReflection('buildWithContext');
 
         static::assertTrue($extension->isMethodSupported($method));
-    }
-
-    /**
-     * Tests that the getTypeFromMethodCall method returns the expected ObjectType
-     * from the first argument.
-     *
-     * @return void
-     *
-     * @throws \PHPStan\Analyser\UndefinedVariableException
-     * @throws \PHPStan\Broker\ClassAutoloadingException
-     * @throws \PHPStan\Broker\ClassNotFoundException
-     * @throws \PHPStan\Broker\FunctionNotFoundException
-     * @throws \PHPStan\Reflection\MissingConstantFromReflectionException
-     * @throws \PHPStan\Reflection\MissingMethodFromReflectionException
-     * @throws \PHPStan\Reflection\MissingPropertyFromReflectionException
-     * @throws \PHPStan\ShouldNotHappenException
-     */
-    public function testGetTypeFromMethodCall(): void
-    {
-        $extension = new ObjectBuilderReturnTypeExtension();
-
-        $method = new DummyMethodReflection('build');
-        $call = new MethodCall(
-            new MethodCall(
-                new Variable('this'),
-                'getObjectBuilder'
-            ),
-            'buildWithContext',
-            [
-                new Arg(
-                    new ClassConstFetch(
-                        new FullyQualified('stdClass'),
-                        'name'
-                    )
-                )
-            ]
-        );
-        $type = new ConstantStringType('stdClass');
-        $scope = new ScopeStub($type);
-
-        $expected = new ObjectType('stdClass');
-
-        $result = $extension->getTypeFromMethodCall(
-            $method,
-            $call,
-            $scope
-        );
-
-        static::assertEquals($expected, $result);
-    }
-
-    /**
-     * Tests that the getTypeFromMethodCall method returns mixed when the first
-     * argument is untyped.
-     *
-     * @return void
-     *
-     * @throws \PHPStan\Analyser\UndefinedVariableException
-     * @throws \PHPStan\Broker\ClassAutoloadingException
-     * @throws \PHPStan\Broker\ClassNotFoundException
-     * @throws \PHPStan\Broker\FunctionNotFoundException
-     * @throws \PHPStan\Reflection\MissingConstantFromReflectionException
-     * @throws \PHPStan\Reflection\MissingMethodFromReflectionException
-     * @throws \PHPStan\Reflection\MissingPropertyFromReflectionException
-     * @throws \PHPStan\ShouldNotHappenException
-     */
-    public function testGetTypeFromMethodCallUntypedParam(): void
-    {
-        $extension = new ObjectBuilderReturnTypeExtension();
-
-        $method = new DummyMethodReflection('build');
-        $call = new MethodCall(
-            new MethodCall(
-                new Variable('this'),
-                'getObjectBuilder'
-            ),
-            'buildWithContext',
-            [
-                new Arg(
-                    new Variable('variable')
-                )
-            ]
-        );
-        $type = new ConstantIntegerType(5);
-        $scope = new ScopeStub($type);
-
-        $expected = new MixedType();
-
-        $result = $extension->getTypeFromMethodCall(
-            $method,
-            $call,
-            $scope
-        );
-
-        static::assertEquals($expected, $result);
     }
 }

--- a/tests/Bridge/PhpStan/RequestObjectTestHelperReturnTypeExtensionTest.php
+++ b/tests/Bridge/PhpStan/RequestObjectTestHelperReturnTypeExtensionTest.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Bridge\PhpStan;
+
+use LoyaltyCorp\RequestHandlers\Bridge\PhpStan\RequestObjectTestHelperReturnTypeExtension;
+use LoyaltyCorp\RequestHandlers\TestHelper\RequestObjectTestHelper;
+use PHPStan\Reflection\Dummy\DummyMethodReflection;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\RequestHandlers\Bridge\PhpStan\RequestObjectTestHelperReturnTypeExtension
+ */
+class RequestObjectTestHelperReturnTypeExtensionTest extends TestCase
+{
+    /**
+     * Supported methods.
+     *
+     * @return string[][]
+     */
+    public function getSupportedMethods(): array
+    {
+        return [
+            ['buildFailingRequest'],
+            ['buildUnvalidatedRequest'],
+            ['buildValidatedRequest']
+        ];
+    }
+
+    /**
+     * Tests what class the extension supports.
+     *
+     * @return void
+     */
+    public function testSupportedClass(): void
+    {
+        $extension = new RequestObjectTestHelperReturnTypeExtension();
+
+        static::assertSame(RequestObjectTestHelper::class, $extension->getClass());
+    }
+
+    /**
+     * Tests extension supports build method
+     *
+     * @param string $method
+     *
+     * @return void
+     *
+     * @dataProvider getSupportedMethods
+     */
+    public function testSupportedMethod(string $method): void
+    {
+        $extension = new RequestObjectTestHelperReturnTypeExtension();
+
+        $method = new DummyMethodReflection($method);
+
+        static::assertTrue($extension->isMethodSupported($method));
+    }
+}


### PR DESCRIPTION
Adds capability to PHPStan to detect return type for the RequestObjectTestHelper(instead of just the ObjectBuilder)