### PR TITLE
PYMT - 1091: Fix RequestObjectTestHelper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.idea/

--- a/src/TestHelper/RequestObjectTestHelper.php
+++ b/src/TestHelper/RequestObjectTestHelper.php
@@ -150,13 +150,10 @@ final class RequestObjectTestHelper
         );
 
         $actual = [];
-        foreach ($methodsToCheck as $method) {
-            $length = 3;
-            if (\strncmp($method, 'is', 2) === 0) {
-                $length = 2;
-            }
+        \asort($methodsToCheck);
 
-            $property = \lcfirst(\substr($method, $length));
+        foreach ($methodsToCheck as $method) {
+            $property = \lcfirst(\substr($method, \strncmp($method, 'get', 3) === 0 ? 3 : 2));
             $callable = [$object, $method];
             if (\is_callable($callable) === false) {
                 // @codeCoverageIgnoreStart

--- a/src/TestHelper/RequestObjectTestHelper.php
+++ b/src/TestHelper/RequestObjectTestHelper.php
@@ -153,8 +153,10 @@ final class RequestObjectTestHelper
         \asort($methodsToCheck);
 
         foreach ($methodsToCheck as $method) {
-            $property = \lcfirst(\substr($method, \strncmp($method, 'get', 3) === 0 ? 3 : 2));
+            $length = \strncmp($method, 'get', 3) === 0 ? 3 : 2;
+            $property = \lcfirst(\substr($method, $length));
             $callable = [$object, $method];
+
             if (\is_callable($callable) === false) {
                 // @codeCoverageIgnoreStart
                 // Unable to be tested. get_class_methods returns only public methods

--- a/src/TestHelper/RequestObjectTestHelper.php
+++ b/src/TestHelper/RequestObjectTestHelper.php
@@ -151,7 +151,7 @@ final class RequestObjectTestHelper
 
         $actual = [];
 
-        //sorting methods alphabetically to return all the gets first then is.
+        // Sorting $methodsToCheck alphabetically to return all the methods starts with 'get' first then 'is'.
         \asort($methodsToCheck);
 
         foreach ($methodsToCheck as $method) {

--- a/src/TestHelper/RequestObjectTestHelper.php
+++ b/src/TestHelper/RequestObjectTestHelper.php
@@ -144,14 +144,19 @@ final class RequestObjectTestHelper
         $methodsToCheck = \array_filter(
             \array_diff($instanceMethods, $interfaceMethods),
             static function (string $method): bool {
-                return \strncmp($method, 'get', 3) === 0;
+                return \strncmp($method, 'get', 3) === 0 ||
+                    \strncmp($method, 'is', 2) === 0;
             }
         );
 
         $actual = [];
         foreach ($methodsToCheck as $method) {
-            $property = \lcfirst(\substr($method, 3));
+            $length = 3;
+            if (\strncmp($method, 'is', 2) === 0) {
+                $length = 2;
+            }
 
+            $property = \lcfirst(\substr($method, $length));
             $callable = [$object, $method];
             if (\is_callable($callable) === false) {
                 // @codeCoverageIgnoreStart

--- a/src/TestHelper/RequestObjectTestHelper.php
+++ b/src/TestHelper/RequestObjectTestHelper.php
@@ -150,6 +150,8 @@ final class RequestObjectTestHelper
         );
 
         $actual = [];
+
+        //sorting methods alphabetically to return all the gets first then is.
         \asort($methodsToCheck);
 
         foreach ($methodsToCheck as $method) {

--- a/tests/Fixtures/TestRequest.php
+++ b/tests/Fixtures/TestRequest.php
@@ -68,6 +68,16 @@ class TestRequest implements RequestObjectInterface
     }
 
     /**
+     * Returns another property
+     *
+     * @return mixed
+     */
+    public function getAnotherProperty()
+    {
+        return $this->anotherProperty;
+    }
+
+    /**
      * Returns the bool value of this method
      *
      * @return bool|null
@@ -85,16 +95,6 @@ class TestRequest implements RequestObjectInterface
     public function getProperty()
     {
         return $this->property;
-    }
-
-    /**
-     * Returns another property
-     *
-     * @return mixed
-     */
-    public function getAnotherProperty()
-    {
-        return $this->anotherProperty;
     }
 
     /**

--- a/tests/Fixtures/TestRequest.php
+++ b/tests/Fixtures/TestRequest.php
@@ -21,13 +21,6 @@ class TestRequest implements RequestObjectInterface
      *
      * @var mixed
      */
-    private $property;
-
-    /**
-     * @Assert\Type("string")
-     *
-     * @var mixed
-     */
     private $anotherProperty;
 
     /**
@@ -37,6 +30,13 @@ class TestRequest implements RequestObjectInterface
      */
     private $oneTime;
 
+    /**
+     * @Assert\Type("string")
+     *
+     * @var mixed
+     */
+    private $property;
+    
     /**
      * Constructor
      *

--- a/tests/Fixtures/TestRequest.php
+++ b/tests/Fixtures/TestRequest.php
@@ -36,7 +36,7 @@ class TestRequest implements RequestObjectInterface
      * @var mixed
      */
     private $property;
-    
+
     /**
      * Constructor
      *

--- a/tests/Fixtures/TestRequest.php
+++ b/tests/Fixtures/TestRequest.php
@@ -17,13 +17,32 @@ class TestRequest implements RequestObjectInterface
     private $property;
 
     /**
+     * @Assert\Type("bool")
+     *
+     * @var bool|null
+     */
+    private $oneTime;
+
+    /**
      * Constructor
      *
+     * @param bool|null $oneTime
      * @param mixed $property
      */
-    public function __construct($property = null)
+    public function __construct(?bool $oneTime = null, $property = null)
     {
+        $this->oneTime = $oneTime;
         $this->property = $property;
+    }
+
+    /**
+     * Returns the bool value of this method
+     *
+     * @return bool|null
+     */
+    public function isOneTime(): ?bool
+    {
+        return $this->oneTime;
     }
 
     /**

--- a/tests/Fixtures/TestRequest.php
+++ b/tests/Fixtures/TestRequest.php
@@ -10,11 +10,25 @@ use Tests\LoyaltyCorp\RequestHandlers\Stubs\Exceptions\RequestValidationExceptio
 class TestRequest implements RequestObjectInterface
 {
     /**
+     * @Assert\Type("bool")
+     *
+     * @var bool|null
+     */
+    private $active;
+
+    /**
      * @Assert\Type("string")
      *
      * @var mixed
      */
     private $property;
+
+    /**
+     * @Assert\Type("string")
+     *
+     * @var mixed
+     */
+    private $anotherProperty;
 
     /**
      * @Assert\Type("bool")
@@ -26,13 +40,31 @@ class TestRequest implements RequestObjectInterface
     /**
      * Constructor
      *
+     * @param bool|null $active
      * @param bool|null $oneTime
      * @param mixed $property
+     * @param mixed $anotherProperty
      */
-    public function __construct(?bool $oneTime = null, $property = null)
-    {
+    public function __construct(
+        ?bool $active = null,
+        ?bool $oneTime = null,
+        $property = null,
+        $anotherProperty = null
+    ) {
+        $this->active = $active;
         $this->oneTime = $oneTime;
         $this->property = $property;
+        $this->anotherProperty = $anotherProperty;
+    }
+
+    /**
+     * Returns the bool value of this method
+     *
+     * @return bool|null
+     */
+    public function isActive(): ?bool
+    {
+        return $this->active;
     }
 
     /**
@@ -53,6 +85,16 @@ class TestRequest implements RequestObjectInterface
     public function getProperty()
     {
         return $this->property;
+    }
+
+    /**
+     * Returns another property
+     *
+     * @return mixed
+     */
+    public function getAnotherProperty()
+    {
+        return $this->anotherProperty;
     }
 
     /**

--- a/tests/TestHelper/RequestObjectTestHelperTest.php
+++ b/tests/TestHelper/RequestObjectTestHelperTest.php
@@ -65,10 +65,12 @@ class RequestObjectTestHelperTest extends TestCase
      */
     public function testGetRequestProperties(): void
     {
-        $object = new TestRequest(true, 'test');
+        $object = new TestRequest(true, false, 'test');
         $expected = [
-            'oneTime' => true,
-            'property' => 'test'
+            'anotherProperty' => null,
+            'property' => 'test',
+            'active' => true,
+            'oneTime' => false
         ];
 
         $helper = $this->getHelper($object);

--- a/tests/TestHelper/RequestObjectTestHelperTest.php
+++ b/tests/TestHelper/RequestObjectTestHelperTest.php
@@ -24,8 +24,6 @@ class RequestObjectTestHelperTest extends TestCase
      * Tests buildFailedRequest
      *
      * @return void
-     *
-     * @throws \LoyaltyCorp\RequestHandlers\TestHelper\Exceptions\ValidationFailedException
      */
     public function testBuildFailedRequest(): void
     {
@@ -67,8 +65,9 @@ class RequestObjectTestHelperTest extends TestCase
      */
     public function testGetRequestProperties(): void
     {
-        $object = new TestRequest('test');
+        $object = new TestRequest(true, 'test');
         $expected = [
+            'oneTime' => true,
             'property' => 'test'
         ];
 


### PR DESCRIPTION
[Ticket](https://loyaltycorp.atlassian.net/browse/PYMT-1091)

`getRequestProperties` needs to take into account the methods which start with `is`,  example `isOneTime`