### PR TITLE
Add boolean is prefix support to Test Helper

### DIFF
--- a/src/TestHelper/RequestObjectTestHelper.php
+++ b/src/TestHelper/RequestObjectTestHelper.php
@@ -141,14 +141,14 @@ final class RequestObjectTestHelper
         $interfaceMethods = \get_class_methods(RequestObjectInterface::class);
         $instanceMethods = \get_class_methods($object);
 
-        $instanceMethodsToCheck = \array_diff($instanceMethods, $interfaceMethods);
-        $methodsToCheck = \array_merge(
-            $this->getMethodsByPrefix($instanceMethodsToCheck, 'get'),
-            $this->getMethodsByPrefix($instanceMethodsToCheck, 'is')
+        $instanceOnlyMethods = \array_diff($instanceMethods, $interfaceMethods);
+        $retrieveMethods = \array_merge(
+            $this->getMethodsByPrefix($instanceOnlyMethods, 'get'),
+            $this->getMethodsByPrefix($instanceOnlyMethods, 'is')
         );
 
         $actual = [];
-        foreach ($methodsToCheck as $method => $property) {
+        foreach ($retrieveMethods as $method => $property) {
             $callable = [$object, $method];
             if (\is_callable($callable) === false) {
                 // @codeCoverageIgnoreStart

--- a/src/TestHelper/RequestObjectTestHelper.php
+++ b/src/TestHelper/RequestObjectTestHelper.php
@@ -166,17 +166,17 @@ final class RequestObjectTestHelper
     /**
      * Get list of methods that have the provided prefix.
      *
-     * @param array $methods List of methods to look up.
+     * @param string[] $methods List of methods to look up.
      * @param string $prefix Prefix to look for, eg 'get'.
      *
-     * @return array Map of method to matching property name. eg; 'getFoo' => 'foo'
+     * @return string[] Map of method to matching property name. eg; 'getFoo' => 'foo'
      */
     private function getMethodsByPrefix(array $methods, string $prefix): array
     {
         $response = [];
-        foreach($methods as $method) {
-            if (\strncmp($method, $prefix, strlen($prefix)) === 0) {
-                $response[$method] = \lcfirst(\substr($method, strlen($prefix)));
+        foreach ($methods as $method) {
+            if (\strncmp($method, $prefix, \strlen($prefix)) === 0) {
+                $response[$method] = \lcfirst(\substr($method, \strlen($prefix)));
             }
         }
         return $response;

--- a/src/TestHelper/RequestObjectTestHelper.php
+++ b/src/TestHelper/RequestObjectTestHelper.php
@@ -141,17 +141,14 @@ final class RequestObjectTestHelper
         $interfaceMethods = \get_class_methods(RequestObjectInterface::class);
         $instanceMethods = \get_class_methods($object);
 
-        $methodsToCheck = \array_filter(
-            \array_diff($instanceMethods, $interfaceMethods),
-            static function (string $method): bool {
-                return \strncmp($method, 'get', 3) === 0;
-            }
+        $instanceMethodsToCheck = \array_diff($instanceMethods, $interfaceMethods);
+        $methodsToCheck = \array_merge(
+            $this->getMethodsByPrefix($instanceMethodsToCheck, 'get'),
+            $this->getMethodsByPrefix($instanceMethodsToCheck, 'is')
         );
 
         $actual = [];
-        foreach ($methodsToCheck as $method) {
-            $property = \lcfirst(\substr($method, 3));
-
+        foreach ($methodsToCheck as $method => $property) {
             $callable = [$object, $method];
             if (\is_callable($callable) === false) {
                 // @codeCoverageIgnoreStart
@@ -164,5 +161,24 @@ final class RequestObjectTestHelper
         }
 
         return $actual;
+    }
+
+    /**
+     * Get list of methods that have the provided prefix.
+     *
+     * @param array $methods List of methods to look up.
+     * @param string $prefix Prefix to look for, eg 'get'.
+     *
+     * @return array Map of method to matching property name. eg; 'getFoo' => 'foo'
+     */
+    private function getMethodsByPrefix(array $methods, string $prefix): array
+    {
+        $response = [];
+        foreach($methods as $method) {
+            if (\strncmp($method, $prefix, strlen($prefix)) === 0) {
+                $response[$method] = \lcfirst(\substr($method, strlen($prefix)));
+            }
+        }
+        return $response;
     }
 }

--- a/tests/Fixtures/TestBooleanRequest.php
+++ b/tests/Fixtures/TestBooleanRequest.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Fixtures;
+
+use LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Exceptions\RequestValidationExceptionStub;
+
+class TestBooleanRequest implements RequestObjectInterface
+{
+    /**
+     * @Assert\Type("bool")
+     *
+     * @var bool
+     */
+    private $boolProperty;
+
+    /**
+     * TestRequest constructor.
+     * @param bool $boolProperty
+     */
+    public function __construct(bool $boolProperty)
+    {
+        $this->boolProperty = $boolProperty;
+    }
+
+    /**
+     * Returns the boolean property.
+     *
+     * @return bool
+     */
+    public function isBoolProperty(): bool
+    {
+        return $this->boolProperty;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getExceptionClass(): string
+    {
+        return RequestValidationExceptionStub::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolveValidationGroups(): array
+    {
+        return [];
+    }
+}

--- a/tests/Fixtures/TestBooleanRequest.php
+++ b/tests/Fixtures/TestBooleanRequest.php
@@ -18,6 +18,7 @@ class TestBooleanRequest implements RequestObjectInterface
 
     /**
      * TestRequest constructor.
+     *
      * @param bool $boolProperty
      */
     public function __construct(bool $boolProperty)

--- a/tests/TestHelper/RequestObjectTestHelperTest.php
+++ b/tests/TestHelper/RequestObjectTestHelperTest.php
@@ -9,6 +9,7 @@ use LoyaltyCorp\RequestHandlers\TestHelper\RequestObjectTestHelper;
 use RuntimeException;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Tests\LoyaltyCorp\RequestHandlers\Fixtures\TestBooleanRequest;
 use Tests\LoyaltyCorp\RequestHandlers\Fixtures\TestRequest;
 use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Illuminate\Contracts\Foundation\ApplicationStub;
 use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Symfony\SerializerStub;
@@ -70,6 +71,25 @@ class RequestObjectTestHelperTest extends TestCase
         $object = new TestRequest('test');
         $expected = [
             'property' => 'test'
+        ];
+
+        $helper = $this->getHelper($object);
+
+        $properties = $helper->getRequestProperties($object);
+
+        static::assertSame($expected, $properties);
+    }
+
+    /**
+     * Test retrieving boolean properties from a request object.
+     *
+     * @return void
+     */
+    public function testGetBooleanProperties(): void
+    {
+        $object = new TestBooleanRequest(true);
+        $expected = [
+            'boolProperty' => true
         ];
 
         $helper = $this->getHelper($object);


### PR DESCRIPTION
* Adds support to RequestObjectTestHelper for `isXyz()` boolean methods.

Accidentally solved PYMT-1091