### PR TITLE
PR-1203 Add SerialisableResponse interface

### DIFF
--- a/src/Response/AbstractSerialisableResponse.php
+++ b/src/Response/AbstractSerialisableResponse.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Response;
+
+use LoyaltyCorp\RequestHandlers\Response\Interfaces\SerialisableResponseInterface;
+
+/**
+ * @SuppressWarnings(PHPMD.CamelCasePropertyName)
+ */
+class AbstractSerialisableResponse implements SerialisableResponseInterface
+{
+    /**
+     * The HTTP Status code of the response.
+     *
+     * This property is intentionally prefixed with an underscore - it is an internal
+     * implementation detail of this abstract class. The serialiser will not serialise
+     * this response code.
+     *
+     * @var int
+     */
+    private $_statusCode; // phpcs:disable PSR2.Classes.PropertyDeclaration.Underscore
+
+    /**
+     * Returns the HTTP status code of the response.
+     *
+     * @return int|null
+     */
+    public function getStatusCode(): ?int
+    {
+        return $this->_statusCode;
+    }
+
+    /**
+     * Sets the status code to be returned by the response.
+     *
+     * @param int $statusCode
+     *
+     * @return void
+     */
+    protected function setStatusCode(int $statusCode): void
+    {
+        $this->_statusCode = $statusCode;
+    }
+}

--- a/src/Response/Interfaces/SerialisableResponseInterface.php
+++ b/src/Response/Interfaces/SerialisableResponseInterface.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Response\Interfaces;
+
+interface SerialisableResponseInterface
+{
+    /**
+     * Returns the HTTP status code for the response.
+     *
+     * @return int|null
+     */
+    public function getStatusCode(): ?int;
+}

--- a/tests/Responses/AbstractSerialisableResponseTest.php
+++ b/tests/Responses/AbstractSerialisableResponseTest.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Responses;
+
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Responses\SerialisableResponse;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+class AbstractSerialisableResponseTest extends TestCase
+{
+    /**
+     * Tests that the status code is set and returned properly.
+     *
+     * @return void
+     */
+    public function testStatusCode(): void
+    {
+        $response = new SerialisableResponse(202);
+
+        static::assertSame(202, $response->getStatusCode());
+    }
+
+    /**
+     * Tests that the status code is set and returned properly.
+     *
+     * @return void
+     */
+    public function testStatusCodeNotSet(): void
+    {
+        $response = new SerialisableResponse(202);
+
+        static::assertSame(202, $response->getStatusCode());
+    }
+}

--- a/tests/Stubs/Responses/SerialisableResponse.php
+++ b/tests/Stubs/Responses/SerialisableResponse.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Stubs\Responses;
+
+use LoyaltyCorp\RequestHandlers\Response\AbstractSerialisableResponse;
+
+/**
+ * @coversNothing
+ */
+class SerialisableResponse extends AbstractSerialisableResponse
+{
+    /**
+     * Constructor
+     *
+     * @param int $statusCode
+     */
+    public function __construct(?int $statusCode)
+    {
+        if ($statusCode !== null) {
+            $this->setStatusCode($statusCode);
+        }
+    }
+}


### PR DESCRIPTION
This adds the base SerialisableResponseInterface and an abstract implementation that handles status codes.