### PR TITLE
PYMT-937 Move primary serialisation into its own service

### DIFF
--- a/src/Bridge/Laravel/Providers/SerialisableResponseProvider.php
+++ b/src/Bridge/Laravel/Providers/SerialisableResponseProvider.php
@@ -6,6 +6,8 @@ namespace LoyaltyCorp\RequestHandlers\Bridge\Laravel\Providers;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\ServiceProvider;
 use LoyaltyCorp\RequestHandlers\Middleware\SerialisableResponseMiddleware;
+use LoyaltyCorp\RequestHandlers\Response\Interfaces\ResponseSerialiserInterface;
+use LoyaltyCorp\RequestHandlers\Response\ResponseSerialiser;
 
 class SerialisableResponseProvider extends ServiceProvider
 {
@@ -16,13 +18,15 @@ class SerialisableResponseProvider extends ServiceProvider
      */
     public function register(): void
     {
+        $this->app->bind(SerialisableResponseMiddleware::class);
+
         $this->app->bind(
-            SerialisableResponseMiddleware::class,
-            static function (Container $app): SerialisableResponseMiddleware {
+            ResponseSerialiserInterface::class,
+            static function (Container $app): ResponseSerialiserInterface {
                 $ignoredAttributes = ['_statusCode'];
                 $normaliser = $app->make('requesthandlers_serializer');
 
-                return new SerialisableResponseMiddleware($ignoredAttributes, $normaliser);
+                return new ResponseSerialiser($ignoredAttributes, $normaliser);
             }
         );
     }

--- a/src/Middleware/SerialisableResponseMiddleware.php
+++ b/src/Middleware/SerialisableResponseMiddleware.php
@@ -4,42 +4,26 @@ declare(strict_types=1);
 namespace LoyaltyCorp\RequestHandlers\Middleware;
 
 use Closure;
-use DateTimeZone;
 use EoneoPay\ApiFormats\Bridge\Laravel\Responses\FormattedApiResponse;
-use EoneoPay\Utils\Interfaces\UtcDateTimeInterface;
 use Illuminate\Http\Request;
-use LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException;
-use LoyaltyCorp\RequestHandlers\Exceptions\ResponseNormaliserException;
+use LoyaltyCorp\RequestHandlers\Response\Interfaces\ResponseSerialiserInterface;
 use LoyaltyCorp\RequestHandlers\Response\Interfaces\SerialisableResponseInterface;
-use Symfony\Component\Serializer\Exception\ExceptionInterface;
-use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class SerialisableResponseMiddleware
 {
     /**
-     * An array of attributes to ignore when normalising the response objects
-     * into arrays.
-     *
-     * @var string[]
+     * @var \LoyaltyCorp\RequestHandlers\Response\Interfaces\ResponseSerialiserInterface
      */
-    private $ignoredAttributes;
+    private $responseSerialiser;
 
     /**
-     * @var \Symfony\Component\Serializer\Normalizer\NormalizerInterface
-     */
-    private $normalizer;
-
-    /**
-     * Constructor
+     * Constructor.
      *
-     * @param string[] $ignoredAttributes
-     * @param \Symfony\Component\Serializer\Normalizer\NormalizerInterface $normalizer
+     * @param \LoyaltyCorp\RequestHandlers\Response\Interfaces\ResponseSerialiserInterface $responseSerialiser
      */
-    public function __construct(array $ignoredAttributes, NormalizerInterface $normalizer)
+    public function __construct(ResponseSerialiserInterface $responseSerialiser)
     {
-        $this->ignoredAttributes = $ignoredAttributes;
-        $this->normalizer = $normalizer;
+        $this->responseSerialiser = $responseSerialiser;
     }
 
     /**
@@ -51,9 +35,6 @@ class SerialisableResponseMiddleware
      * @param \Closure $next
      *
      * @return mixed|\EoneoPay\ApiFormats\Interfaces\FormattedApiResponseInterface
-     *
-     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException
-     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\ResponseNormaliserException
      */
     public function handle(Request $request, Closure $next)
     {
@@ -69,49 +50,8 @@ class SerialisableResponseMiddleware
          * @see https://youtrack.jetbrains.com/issue/WI-37859 - typehint required until PhpStorm recognises === chec
          */
 
-        $normalised = $this->normalise($response);
+        $normalised = $this->responseSerialiser->normalise($response);
 
         return new FormattedApiResponse($normalised, $response->getStatusCode());
-    }
-
-    /**
-     * Performs a normalisation on the response if one can be performed.
-     *
-     * @param \LoyaltyCorp\RequestHandlers\Response\Interfaces\SerialisableResponseInterface $response
-     *
-     * @return mixed
-     *
-     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException
-     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\ResponseNormaliserException
-     */
-    private function normalise(SerialisableResponseInterface $response)
-    {
-        if ($this->normalizer->supportsNormalization($response) === false) {
-            throw new MisconfiguredSerializerException(
-                'The serialiser is not configured to support serialisable response objects.'
-            );
-        }
-
-        try {
-            // The json format used in this method call is a hint to any normalisers in the
-            // serialiser that allows it to make assumptions about the data format we will
-            // be returning. This does not preclude the use of the resulting normalised data
-            // being serialised into XML by other middleware.
-            $result = $this->normalizer->normalize($response, 'json', [
-                'ignored_attributes' => $this->ignoredAttributes,
-                // Force the normalisation of datetimes to UTC
-                DateTimeNormalizer::FORMAT_KEY => UtcDateTimeInterface::FORMAT_ZULU,
-                DateTimeNormalizer::TIMEZONE_KEY => new DateTimeZone('UTC')
-            ]);
-        } catch (ExceptionInterface $exception) {
-            throw new ResponseNormaliserException(
-                'An exception occurred while trying to serialise a response.',
-                null,
-                null,
-                $exception
-            );
-        }
-
-        return $result;
     }
 }

--- a/src/Response/Interfaces/ResponseSerialiserInterface.php
+++ b/src/Response/Interfaces/ResponseSerialiserInterface.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Response\Interfaces;
+
+interface ResponseSerialiserInterface
+{
+    /**
+     * Performs a normalisation on the response if one can be performed.
+     *
+     * @param \LoyaltyCorp\RequestHandlers\Response\Interfaces\SerialisableResponseInterface $response
+     *
+     * @return mixed[]
+     */
+    public function normalise(SerialisableResponseInterface $response): array;
+}

--- a/src/Response/ResponseSerialiser.php
+++ b/src/Response/ResponseSerialiser.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Response;
+
+use DateTimeZone;
+use EoneoPay\Utils\Interfaces\UtcDateTimeInterface;
+use LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException;
+use LoyaltyCorp\RequestHandlers\Exceptions\ResponseNormaliserException;
+use LoyaltyCorp\RequestHandlers\Response\Interfaces\ResponseSerialiserInterface;
+use LoyaltyCorp\RequestHandlers\Response\Interfaces\SerialisableResponseInterface;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class ResponseSerialiser implements ResponseSerialiserInterface
+{
+    /**
+     * An array of attributes to ignore when normalising the response objects
+     * into arrays.
+     *
+     * @var string[]
+     */
+    private $ignoredAttributes;
+
+    /**
+     * @var \Symfony\Component\Serializer\Normalizer\NormalizerInterface
+     */
+    private $normalizer;
+
+    /**
+     * Constructor
+     *
+     * @param string[] $ignoredAttributes
+     * @param \Symfony\Component\Serializer\Normalizer\NormalizerInterface $normalizer
+     */
+    public function __construct(array $ignoredAttributes, NormalizerInterface $normalizer)
+    {
+        $this->ignoredAttributes = $ignoredAttributes;
+        $this->normalizer = $normalizer;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\ResponseNormaliserException
+     */
+    public function normalise(SerialisableResponseInterface $response): array
+    {
+        if ($this->normalizer->supportsNormalization($response) === false) {
+            throw new MisconfiguredSerializerException(
+                'The serialiser is not configured to support serialisable response objects.'
+            );
+        }
+
+        try {
+            // The json format used in this method call is a hint to any normalisers in the
+            // serialiser that allows it to make assumptions about the data format we will
+            // be returning. This does not preclude the use of the resulting normalised data
+            // being serialised into XML by other middleware.
+            $result = $this->normalizer->normalize($response, 'json', [
+                'ignored_attributes' => $this->ignoredAttributes,
+                // Force the normalisation of datetimes to UTC
+                DateTimeNormalizer::FORMAT_KEY => UtcDateTimeInterface::FORMAT_ZULU,
+                DateTimeNormalizer::TIMEZONE_KEY => new DateTimeZone('UTC')
+            ]);
+        } catch (ExceptionInterface $exception) {
+            throw new ResponseNormaliserException(
+                'An exception occurred while trying to serialise a response.',
+                null,
+                null,
+                $exception
+            );
+        }
+
+        if (\is_array($result) === false) {
+            throw new MisconfiguredSerializerException(
+                'The serialiser is not configured to return an array when normalising a response object.'
+            );
+        }
+
+        return $result;
+    }
+}

--- a/tests/Middleware/SerialisableResponseMiddlewareTest.php
+++ b/tests/Middleware/SerialisableResponseMiddlewareTest.php
@@ -5,12 +5,9 @@ namespace Tests\LoyaltyCorp\RequestHandlers\Middleware;
 
 use EoneoPay\ApiFormats\Bridge\Laravel\Responses\FormattedApiResponse;
 use Illuminate\Http\Request;
-use LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException;
-use LoyaltyCorp\RequestHandlers\Exceptions\ResponseNormaliserException;
 use LoyaltyCorp\RequestHandlers\Middleware\SerialisableResponseMiddleware;
-use Symfony\Component\Serializer\Exception\CircularReferenceException;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Responses\ResponseSerialiserStub;
 use Tests\LoyaltyCorp\RequestHandlers\Stubs\Responses\SerialisableResponse;
-use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Symfony\NormaliserStub;
 use Tests\LoyaltyCorp\RequestHandlers\TestCase;
 
 /**
@@ -24,40 +21,11 @@ class SerialisableResponseMiddlewareTest extends TestCase
      * SerialisableResponseInterface.
      *
      * @return void
-     *
-     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException
-     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\ResponseNormaliserException
-     */
-    public function testNotSupportedResponse(): void
-    {
-        $normaliser = new NormaliserStub(null, false);
-
-        $middleware = new SerialisableResponseMiddleware([], $normaliser);
-
-        $next = static function () {
-            return new SerialisableResponse(200);
-        };
-
-        $this->expectException(MisconfiguredSerializerException::class);
-        $this->expectExceptionMessage('The serialiser is not configured to support serialisable response objects.');
-
-        $middleware->handle(new Request(), $next);
-    }
-
-    /**
-     * Tests that the middleware throws a MisconfiguredSerialiser exception when
-     * the injected serialiser doesnt support normalising an instance of
-     * SerialisableResponseInterface.
-     *
-     * @return void
-     *
-     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException
-     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\ResponseNormaliserException
      */
     public function testPassThroughNonResponse(): void
     {
-        $normaliser = new NormaliserStub(null, true);
-        $middleware = new SerialisableResponseMiddleware([], $normaliser);
+        $responseSerialiser = new ResponseSerialiserStub([]);
+        $middleware = new SerialisableResponseMiddleware($responseSerialiser);
 
         $next = static function () {
             return 'hello';
@@ -73,46 +41,20 @@ class SerialisableResponseMiddlewareTest extends TestCase
      * the correct status code.
      *
      * @return void
-     *
-     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException
-     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\ResponseNormaliserException
      */
     public function testCorrectReturn(): void
     {
-        $normaliser = new NormaliserStub('PURPLE ELEPHANTS', true);
-        $middleware = new SerialisableResponseMiddleware([], $normaliser);
+        $responseSerialiser = new ResponseSerialiserStub(['PURPLE' => 'ELEPHANTS']);
+        $middleware = new SerialisableResponseMiddleware($responseSerialiser);
 
         $next = static function () {
             return new SerialisableResponse(202);
         };
 
-        $expected = new FormattedApiResponse('PURPLE ELEPHANTS', 202);
+        $expected = new FormattedApiResponse(['PURPLE' => 'ELEPHANTS'], 202);
 
         $result = $middleware->handle(new Request(), $next);
 
         static::assertEquals($expected, $result);
-    }
-
-    /**
-     * Tests that the middleware wraps any serialiser exception with its own.
-     *
-     * @return void
-     *
-     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException
-     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\ResponseNormaliserException
-     */
-    public function testThrowsOnSerialiserFailure(): void
-    {
-        $normaliser = new NormaliserStub(new CircularReferenceException(), true);
-        $middleware = new SerialisableResponseMiddleware([], $normaliser);
-
-        $next = static function () {
-            return new SerialisableResponse(200);
-        };
-
-        $this->expectException(ResponseNormaliserException::class);
-        $this->expectExceptionMessage('An exception occurred while trying to serialise a response.');
-
-        $middleware->handle(new Request(), $next);
     }
 }

--- a/tests/Responses/ResponseSerialiserTest.php
+++ b/tests/Responses/ResponseSerialiserTest.php
@@ -11,6 +11,9 @@ use Tests\LoyaltyCorp\RequestHandlers\Stubs\Responses\SerialisableResponse;
 use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Symfony\NormaliserStub;
 use Tests\LoyaltyCorp\RequestHandlers\TestCase;
 
+/**
+ * @covers \LoyaltyCorp\RequestHandlers\Response\ResponseSerialiser
+ */
 class ResponseSerialiserTest extends TestCase
 {
     /**
@@ -37,8 +40,7 @@ class ResponseSerialiserTest extends TestCase
     }
 
     /**
-     * Tests that an exception is thrown when the underlying serialiser
-     * is configured to not support a response object.
+     * Tests that the normalise response is as expected.
      *
      * @return void
      *

--- a/tests/Responses/ResponseSerialiserTest.php
+++ b/tests/Responses/ResponseSerialiserTest.php
@@ -1,0 +1,108 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Responses;
+
+use LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException;
+use LoyaltyCorp\RequestHandlers\Exceptions\ResponseNormaliserException;
+use LoyaltyCorp\RequestHandlers\Response\ResponseSerialiser;
+use Symfony\Component\Serializer\Exception\CircularReferenceException;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Responses\SerialisableResponse;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Symfony\NormaliserStub;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+class ResponseSerialiserTest extends TestCase
+{
+    /**
+     * Tests that an exception is thrown when the underlying serialiser
+     * is configured to not support a response object.
+     *
+     * @return void
+     *
+     * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\ResponseNormaliserException
+     */
+    public function testNormaliseReturnsNonArray(): void
+    {
+        $normaliser = new NormaliserStub('green', true);
+        $serialiser = new ResponseSerialiser([], $normaliser);
+
+        $this->expectException(MisconfiguredSerializerException::class);
+        $this->expectExceptionMessage(
+            'The serialiser is not configured to return an array when normalising a response object.'
+        );
+
+        $serialiser->normalise(new SerialisableResponse(204));
+    }
+
+    /**
+     * Tests that an exception is thrown when the underlying serialiser
+     * is configured to not support a response object.
+     *
+     * @return void
+     *
+     * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\ResponseNormaliserException
+     */
+    public function testNormalise(): void
+    {
+        $normaliser = new NormaliserStub(['green' => 'apples'], true);
+        $serialiser = new ResponseSerialiser([], $normaliser);
+
+        $expected = ['green' => 'apples'];
+
+        $result = $serialiser->normalise(new SerialisableResponse(204));
+
+        static::assertSame($expected, $result);
+    }
+
+    /**
+     * Tests that an exception is thrown when the underlying serialiser
+     * is configured to not support a response object.
+     *
+     * @return void
+     *
+     * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException
+     */
+    public function testNormaliseThrows(): void
+    {
+        $inner = new CircularReferenceException();
+        $normaliser = new NormaliserStub($inner, true);
+        $serialiser = new ResponseSerialiser([], $normaliser);
+
+        try {
+            $serialiser->normalise(new SerialisableResponse(204));
+        } catch (ResponseNormaliserException $exception) {
+            static::assertSame($inner, $exception->getPrevious());
+            static::assertSame('An exception occurred while trying to serialise a response.', $exception->getMessage());
+
+            return;
+        }
+
+        self::fail('Exception was not caught.');
+    }
+
+    /**
+     * Tests that an exception is thrown when the underlying serialiser
+     * is configured to not support a response object.
+     *
+     * @return void
+     *
+     * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\MisconfiguredSerializerException
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\ResponseNormaliserException
+     */
+    public function testNormaliseUnsupported(): void
+    {
+        $normaliser = new NormaliserStub(null, false);
+        $serialiser = new ResponseSerialiser([], $normaliser);
+
+        $this->expectException(MisconfiguredSerializerException::class);
+        $this->expectExceptionMessage('The serialiser is not configured to support serialisable response objects.');
+
+        $serialiser->normalise(new SerialisableResponse(204));
+    }
+}

--- a/tests/Stubs/Responses/ResponseSerialiserStub.php
+++ b/tests/Stubs/Responses/ResponseSerialiserStub.php
@@ -6,6 +6,9 @@ namespace Tests\LoyaltyCorp\RequestHandlers\Stubs\Responses;
 use LoyaltyCorp\RequestHandlers\Response\Interfaces\ResponseSerialiserInterface;
 use LoyaltyCorp\RequestHandlers\Response\Interfaces\SerialisableResponseInterface;
 
+/**
+ * @coversNothing
+ */
 class ResponseSerialiserStub implements ResponseSerialiserInterface
 {
     /**

--- a/tests/Stubs/Responses/ResponseSerialiserStub.php
+++ b/tests/Stubs/Responses/ResponseSerialiserStub.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Stubs\Responses;
+
+use LoyaltyCorp\RequestHandlers\Response\Interfaces\ResponseSerialiserInterface;
+use LoyaltyCorp\RequestHandlers\Response\Interfaces\SerialisableResponseInterface;
+
+class ResponseSerialiserStub implements ResponseSerialiserInterface
+{
+    /**
+     * @var mixed[]
+     */
+    private $result;
+
+    /**
+     * Constructor
+     *
+     * @param mixed[] $result
+     */
+    public function __construct(array $result)
+    {
+        $this->result = $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalise(SerialisableResponseInterface $response): array
+    {
+        return $this->result;
+    }
+}


### PR DESCRIPTION
The webhook payload builders need access to the same serialisation logic that is performed by the middleware, this extracts that out into a service that can be used in both places.
