### PR TITLE
PYMT-1339 Implement InjectedFromContext annotation

### DIFF
--- a/src/Annotations/InjectedFromContext.php
+++ b/src/Annotations/InjectedFromContext.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Annotations;
+
+/**
+ * This annotation is used on properties to indicate that they should only be injected from
+ * the context of the request and not be processed from the request body.
+ *
+ * It allows for things like the object from the request URL to be resolved and injected
+ * into the request object for additional validation purposes.
+ *
+ * @Annotation
+ */
+class InjectedFromContext
+{
+}

--- a/src/Annotations/InjectedFromContext.php
+++ b/src/Annotations/InjectedFromContext.php
@@ -5,7 +5,7 @@ namespace LoyaltyCorp\RequestHandlers\Annotations;
 
 /**
  * This annotation is used on properties to indicate that they should only be injected from
- * the context of the request and not be processed from the request body.
+ * the context of the request and not be populated with data from the request body.
  *
  * It allows for things like the object from the request URL to be resolved and injected
  * into the request object for additional validation purposes.

--- a/src/Bridge/Laravel/Providers/ParamConverterProvider.php
+++ b/src/Bridge/Laravel/Providers/ParamConverterProvider.php
@@ -8,6 +8,7 @@ use DateTimeZone;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use EoneoPay\Utils\AnnotationReader;
+use EoneoPay\Utils\Interfaces\AnnotationReaderInterface;
 use FOS\RestBundle\Serializer\SymfonySerializerAdapter;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\ServiceProvider;
@@ -195,6 +196,7 @@ final class ParamConverterProvider extends ServiceProvider
             $phpDocExtractor = new PhpDocExtractor();
 
             return new PropertyNormalizer(
+                $app->make(AnnotationReaderInterface::class),
                 $app->make(ClassMetadataFactoryInterface::class),
                 new CamelCaseToSnakeCaseNameConverter(),
                 new PropertyInfoExtractor(

--- a/src/Serializer/PropertyNormalizer.php
+++ b/src/Serializer/PropertyNormalizer.php
@@ -3,6 +3,12 @@ declare(strict_types=1);
 
 namespace LoyaltyCorp\RequestHandlers\Serializer;
 
+use EoneoPay\Utils\Interfaces\AnnotationReaderInterface;
+use LoyaltyCorp\RequestHandlers\Annotations\InjectedFromContext;
+use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
+use Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 use Symfony\Component\Serializer\Normalizer\PropertyNormalizer as BasePropertyNormalizer;
 
 final class PropertyNormalizer extends BasePropertyNormalizer
@@ -11,6 +17,45 @@ final class PropertyNormalizer extends BasePropertyNormalizer
      * Allows for the addition of extra properties to be set when denormalizing
      */
     public const EXTRA_PARAMETERS = 'extra_parameters';
+
+    /**
+     * @var \EoneoPay\Utils\Interfaces\AnnotationReaderInterface
+     */
+    private $annotationReader;
+
+    /**
+     * Constructor
+     *
+     * @param \EoneoPay\Utils\Interfaces\AnnotationReaderInterface $annotationReader
+     * @param null|\Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface $classMetadataFactory
+     * @param null|\Symfony\Component\Serializer\NameConverter\NameConverterInterface $nameConverter
+     * @param null|\Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface $propertyTypeExtractor
+     * @param null|\Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface $classDiscriminatorResolver
+     * @param callable|null $objectClassResolver
+     * @param mixed[]|null $defaultContext
+     *
+     * @SuppressWarnings(PHPMD.LongVariable) Required from extended class
+     */
+    public function __construct(
+        AnnotationReaderInterface $annotationReader,
+        ?ClassMetadataFactoryInterface $classMetadataFactory = null,
+        ?NameConverterInterface $nameConverter = null,
+        ?PropertyTypeExtractorInterface $propertyTypeExtractor = null,
+        ?ClassDiscriminatorResolverInterface $classDiscriminatorResolver = null,
+        ?callable $objectClassResolver = null,
+        ?array $defaultContext = null
+    ) {
+        parent::__construct(
+            $classMetadataFactory,
+            $nameConverter,
+            $propertyTypeExtractor,
+            $classDiscriminatorResolver,
+            $objectClassResolver,
+            $defaultContext ?? []
+        );
+
+        $this->annotationReader = $annotationReader;
+    }
 
     /**
      * {@inheritdoc}
@@ -50,5 +95,34 @@ final class PropertyNormalizer extends BasePropertyNormalizer
             : $attribute;
 
         return $context;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Overridden to allow InjectFromContext to block request data from making it into object
+     * properties annotated as only being injectable from context.
+     */
+    protected function isAllowedAttribute($classOrObject, $attribute, $format = null, array $context = []): bool
+    {
+        $class = \is_string($classOrObject) === false
+            ? \get_class($classOrObject)
+            : $classOrObject;
+
+        $injected = $this->annotationReader->getClassPropertyAnnotation($class, InjectedFromContext::class);
+
+        // If we found an InjectedFromContext annotation on the attribute we do not want to allow
+        // the attribute to be set by the serialiser. It can still be set if provided by the
+        // EXTRA_PARAMETERS functionality of this class.
+        if ((($injected[$attribute] ?? null) instanceof InjectedFromContext) === true) {
+            return false;
+        }
+
+        return parent::isAllowedAttribute(
+            $classOrObject,
+            $attribute,
+            $format,
+            $context
+        );
     }
 }

--- a/tests/Bridge/Laravel/Providers/ParamConverterProviderTest.php
+++ b/tests/Bridge/Laravel/Providers/ParamConverterProviderTest.php
@@ -6,6 +6,7 @@ namespace Tests\LoyaltyCorp\RequestHandlers\Bridge\Laravel\Providers;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use EoneoPay\Utils\AnnotationReader;
+use EoneoPay\Utils\Interfaces\AnnotationReaderInterface;
 use LoyaltyCorp\RequestHandlers\Bridge\Laravel\Providers\ParamConverterProvider;
 use LoyaltyCorp\RequestHandlers\Builder\Interfaces\ObjectBuilderInterface;
 use LoyaltyCorp\RequestHandlers\Builder\ObjectBuilder;
@@ -53,6 +54,7 @@ class ParamConverterProviderTest extends TestCase
     {
         $application = new ApplicationStub();
         $application->bind(ManagerRegistry::class, ManagerRegistryStub::class);
+        $application->bind(AnnotationReaderInterface::class, AnnotationReader::class);
 
         $application->bind(
             DoctrineDenormalizerEntityFinderInterface::class,

--- a/tests/Integration/Fixtures/ThingRequest.php
+++ b/tests/Integration/Fixtures/ThingRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Tests\LoyaltyCorp\RequestHandlers\Integration\Fixtures;
 
 use EoneoPay\Utils\DateTime;
+use LoyaltyCorp\RequestHandlers\Annotations\InjectedFromContext;
 use LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface;
 use LoyaltyCorp\RequestHandlers\Validators\Filter;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -27,7 +28,9 @@ class ThingRequest implements RequestObjectInterface
      *
      * @Assert\Type("string")
      *
-     * @var string
+     * @InjectedFromContext()
+     *
+     * @var string|null
      */
     private $baz;
 
@@ -97,9 +100,9 @@ class ThingRequest implements RequestObjectInterface
     /**
      * Returns the baz
      *
-     * @return string
+     * @return string|null
      */
-    public function getBaz(): string
+    public function getBaz(): ?string
     {
         return $this->baz;
     }

--- a/tests/Integration/SerialisableResponseMiddlewareTest.php
+++ b/tests/Integration/SerialisableResponseMiddlewareTest.php
@@ -6,6 +6,8 @@ namespace Tests\LoyaltyCorp\RequestHandlers\Integration;
 use Closure;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use EoneoPay\ApiFormats\Bridge\Laravel\Responses\FormattedApiResponse;
+use EoneoPay\Utils\AnnotationReader;
+use EoneoPay\Utils\Interfaces\AnnotationReaderInterface;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Http\Request;
 use Illuminate\Pipeline\Pipeline;
@@ -96,6 +98,7 @@ class SerialisableResponseMiddlewareTest extends TestCase
         $app->instance(Container::class, $app);
         $app->bind(DoctrineDenormalizerEntityFinderInterface::class, DoctrineDenormalizerEntityFinderStub::class);
         $app->bind(ManagerRegistry::class, ManagerRegistryStub::class);
+        $app->bind(AnnotationReaderInterface::class, AnnotationReader::class);
         (new ParamConverterProvider($app))->register();
         (new SerialisableResponseProvider($app))->register();
 

--- a/tests/Serializer/PropertyNormalizerTest.php
+++ b/tests/Serializer/PropertyNormalizerTest.php
@@ -3,9 +3,11 @@ declare(strict_types=1);
 
 namespace Tests\LoyaltyCorp\RequestHandlers\Serializer;
 
+use EoneoPay\Utils\AnnotationReader;
 use LoyaltyCorp\RequestHandlers\Serializer\PropertyNormalizer;
 use ReflectionClass;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+use Tests\LoyaltyCorp\RequestHandlers\Integration\Fixtures\ThingRequest;
 use Tests\LoyaltyCorp\RequestHandlers\Stubs\Request\RequestObjectStub;
 use Tests\LoyaltyCorp\RequestHandlers\TestCase;
 
@@ -20,10 +22,15 @@ class PropertyNormalizerTest extends TestCase
      * @return void
      *
      * @throws \ReflectionException
+     * @throws \EoneoPay\Utils\Exceptions\AnnotationCacheException
      */
     public function testCreateChildContext(): void
     {
-        $normalizer = new PropertyNormalizer(null, new CamelCaseToSnakeCaseNameConverter());
+        $normalizer = new PropertyNormalizer(
+            new AnnotationReader(),
+            null,
+            new CamelCaseToSnakeCaseNameConverter()
+        );
 
         // There is no simple way to test this method call, so lets use the Reflection approach.
         // Bad idea, do not copy.
@@ -42,10 +49,11 @@ class PropertyNormalizerTest extends TestCase
      * @return void
      *
      * @throws \ReflectionException
+     * @throws \EoneoPay\Utils\Exceptions\AnnotationCacheException
      */
     public function testCreateChildContextWithoutNameConverter(): void
     {
-        $normalizer = new PropertyNormalizer();
+        $normalizer = new PropertyNormalizer(new AnnotationReader());
 
         // There is no simple way to test this method call, so lets use the Reflection approach.
         // Bad idea, do not copy.
@@ -64,10 +72,11 @@ class PropertyNormalizerTest extends TestCase
      * @return void
      *
      * @throws \Symfony\Component\Serializer\Exception\ExceptionInterface
+     * @throws \EoneoPay\Utils\Exceptions\AnnotationCacheException
      */
     public function testDenormalize(): void
     {
-        $normalizer = new PropertyNormalizer();
+        $normalizer = new PropertyNormalizer(new AnnotationReader());
 
         /** @var \Tests\LoyaltyCorp\RequestHandlers\Stubs\Request\RequestObjectStub $result */
         $result = $normalizer->denormalize([], RequestObjectStub::class, null, [
@@ -77,5 +86,28 @@ class PropertyNormalizerTest extends TestCase
         ]);
 
         static::assertSame('value', $result->getProperty());
+    }
+
+    /**
+     * Tests that the normalizer does not allow attributes that are annotated with InjectedFromContext
+     *
+     * @return void
+     *
+     * @throws \EoneoPay\Utils\Exceptions\AnnotationCacheException
+     * @throws \ReflectionException
+     */
+    public function testInjectedFromContextClassName(): void
+    {
+        $normalizer = new PropertyNormalizer(new AnnotationReader());
+
+        // There is no simple way to test this method call, so lets use the Reflection approach.
+        // Bad idea, do not copy.
+        $reflectionClass = new ReflectionClass($normalizer);
+        $method = $reflectionClass->getMethod('isAllowedAttribute');
+        $method->setAccessible(true);
+
+        static::assertTrue($method->invoke($normalizer, ThingRequest::class, 'amount'));
+        static::assertFalse($method->invoke($normalizer, ThingRequest::class, 'baz'));
+        static::assertFalse($method->invoke($normalizer, new ThingRequest(), 'baz'));
     }
 }


### PR DESCRIPTION
This PR allows properties on a request object to be annotated with an @InjectedFromContext annotation that will not allow a key from the request body to be used to populate the property.

It wasnt easily possible to produce validation errors when this occurs and silently ignoring is good enough. (which will be overridden by the context value anyway) 