### PR TITLE
PYMT-1313 Allow context overriding by others

### DIFF
--- a/src/Bridge/Laravel/Providers/ParamConverterProvider.php
+++ b/src/Bridge/Laravel/Providers/ParamConverterProvider.php
@@ -18,6 +18,7 @@ use LoyaltyCorp\RequestHandlers\Encoder\JsonEncoder;
 use LoyaltyCorp\RequestHandlers\Encoder\XmlEncoder;
 use LoyaltyCorp\RequestHandlers\EventListeners\ParamConverterListener;
 use LoyaltyCorp\RequestHandlers\Request\DoctrineParamConverter;
+use LoyaltyCorp\RequestHandlers\Request\Interfaces\ContextConfiguratorInterface;
 use LoyaltyCorp\RequestHandlers\Request\Interfaces\ParamConverterManagerInterface;
 use LoyaltyCorp\RequestHandlers\Request\ParamConverterManager;
 use LoyaltyCorp\RequestHandlers\Request\RequestBodyParamConverter;
@@ -126,7 +127,10 @@ final class ParamConverterProvider extends ServiceProvider
                 // Note: we're intentionally not using the Validation component in this
                 // ParamConverter so we can customise the validation to occur at a later time
                 return new RequestBodyParamConverter(
-                    new SymfonySerializerAdapter($serializer)
+                    new SymfonySerializerAdapter($serializer),
+                    $app->has(ContextConfiguratorInterface::class) === true
+                        ? $app->make(ContextConfiguratorInterface::class)
+                        : null
                 );
             }
         );

--- a/src/Request/Interfaces/ContextConfiguratorInterface.php
+++ b/src/Request/Interfaces/ContextConfiguratorInterface.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Request\Interfaces;
+
+use FOS\RestBundle\Context\Context;
+use Symfony\Component\HttpFoundation\Request;
+
+interface ContextConfiguratorInterface
+{
+    /**
+     * Implementors are given the request body deserialisation context to configure
+     * additional parameters in the context.
+     *
+     * @param \FOS\RestBundle\Context\Context $context
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *
+     * @return void
+     */
+    public function configure(Context $context, Request $request): void;
+}

--- a/src/Request/RequestBodyParamConverter.php
+++ b/src/Request/RequestBodyParamConverter.php
@@ -6,20 +6,20 @@ namespace LoyaltyCorp\RequestHandlers\Request;
 use Exception;
 use FOS\RestBundle\Context\Context;
 use FOS\RestBundle\Request\RequestBodyParamConverter as BaseRequestBodyParamConverter;
+use FOS\RestBundle\Serializer\Serializer;
 use LoyaltyCorp\RequestHandlers\Exceptions\InvalidContentTypeException;
+use LoyaltyCorp\RequestHandlers\Request\Interfaces\ContextConfiguratorInterface;
 use LoyaltyCorp\RequestHandlers\Serializer\PropertyNormalizer;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 final class RequestBodyParamConverter extends BaseRequestBodyParamConverter
 {
     /**
-     * Stores the configuration so we can add some detail to the serializer
-     * context.
-     *
-     * @var \Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter|null
+     * @var \LoyaltyCorp\RequestHandlers\Request\Interfaces\ContextConfiguratorInterface|null
      */
-    private $configuration;
+    private $contextConfigurator;
 
     /**
      * Stores the request so we can add it to the serializer context.
@@ -29,16 +29,42 @@ final class RequestBodyParamConverter extends BaseRequestBodyParamConverter
     private $request;
 
     /**
+     * Constructor
+     *
+     * @param \FOS\RestBundle\Serializer\Serializer $serializer
+     * @param \LoyaltyCorp\RequestHandlers\Request\Interfaces\ContextConfiguratorInterface|null $contextConfigurator
+     * @param string[]|null $groups
+     * @param null|string $version
+     * @param null|\Symfony\Component\Validator\Validator\ValidatorInterface $validator
+     */
+    public function __construct(
+        Serializer $serializer,
+        ?ContextConfiguratorInterface $contextConfigurator = null,
+        ?array $groups = null,
+        ?string $version = null,
+        ?ValidatorInterface $validator = null
+    ) {
+        $this->contextConfigurator = $contextConfigurator;
+
+        parent::__construct(
+            $serializer,
+            $groups,
+            $version,
+            $validator
+        );
+    }
+
+    /**
      * Overridden so we can capture the $request and $configuration before the application
      * process, and add those details to the deserialisation context.
      *
      * {@inheritdoc}
      *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\InvalidContentTypeException
      * @throws \Exception
      */
     public function apply(Request $request, ParamConverter $configuration): bool
     {
-        $this->configuration = $configuration;
         $this->request = $request;
 
         if ($request->getContentType() === null) {
@@ -48,18 +74,12 @@ final class RequestBodyParamConverter extends BaseRequestBodyParamConverter
         }
 
         try {
-            $result = parent::apply($request, $configuration);
+            return parent::apply($request, $configuration);
         } catch (Exception $exception) {
-            $this->configuration = null;
-            $this->request = null;
-
             throw $exception;
+        } finally { // @codeCoverageIgnore
+            $this->request = null;
         }
-
-        $this->configuration = null;
-        $this->request = null;
-
-        return $result;
     }
 
     /**
@@ -80,22 +100,31 @@ final class RequestBodyParamConverter extends BaseRequestBodyParamConverter
     }
 
     /**
-     * If we've got a request and a configuration, add default constructor arguments
-     * based on the request's attributes. This allows us to inject anything that is type
-     * hinted on the constructor to be added from the controller arguments.
+     * Overrides the context configuration to add specific behaviours for request
+     * deserialisation.
      *
      * {@inheritdoc}
      */
     protected function configureContext(Context $context, array $options): void
     {
+        // Disable enforcement of types inside the serialiser. This may lead to invalid objects
+        // that have bad data types for their properties, but this is intentional - it allows us
+        // to then validate the objects with a Validator with the data provided instead of nulls
+        // or weird serialiser exceptions.
         $context->setAttribute(PropertyNormalizer::DISABLE_TYPE_ENFORCEMENT, true);
 
-        if ($this->request !== null && $this->configuration !== null) {
-            $context->setAttribute(
-                PropertyNormalizer::EXTRA_PARAMETERS,
-                $this->request->attributes->all()
-            );
+        $attributes = [];
+        if ($this->request instanceof Request === true) {
+            $attributes = $this->request->attributes->all();
+
+            if ($this->contextConfigurator instanceof ContextConfiguratorInterface === true) {
+                // If we have a configurator, allow it to modify the context
+                $this->contextConfigurator->configure($context, $this->request);
+            }
         }
+
+        // Set attributes in the deserialisation to all request attributes if a request exists.
+        $context->setAttribute(PropertyNormalizer::EXTRA_PARAMETERS, $attributes);
 
         parent::configureContext($context, $options);
     }

--- a/tests/Bridge/Laravel/Providers/ParamConverterProviderTest.php
+++ b/tests/Bridge/Laravel/Providers/ParamConverterProviderTest.php
@@ -11,6 +11,7 @@ use LoyaltyCorp\RequestHandlers\Bridge\Laravel\Providers\ParamConverterProvider;
 use LoyaltyCorp\RequestHandlers\Builder\Interfaces\ObjectBuilderInterface;
 use LoyaltyCorp\RequestHandlers\Builder\ObjectBuilder;
 use LoyaltyCorp\RequestHandlers\Request\DoctrineParamConverter;
+use LoyaltyCorp\RequestHandlers\Request\Interfaces\ContextConfiguratorInterface;
 use LoyaltyCorp\RequestHandlers\Request\RequestBodyParamConverter;
 use LoyaltyCorp\RequestHandlers\Serializer\Interfaces\DoctrineDenormalizerEntityFinderInterface;
 use LoyaltyCorp\RequestHandlers\Serializer\RequestBodySerializer;
@@ -35,6 +36,7 @@ use Symfony\Component\Validator\Constraints\NotIdenticalToValidator;
 use Symfony\Component\Validator\ConstraintValidatorFactoryInterface;
 use Symfony\Component\Validator\ContainerConstraintValidatorFactory;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Request\ContextConfiguratorStub;
 use Tests\LoyaltyCorp\RequestHandlers\Stubs\Serializer\DoctrineDenormalizerEntityFinderStub;
 use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Doctrine\Common\Persistence\ManagerRegistryStub;
 use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Illuminate\Contracts\Foundation\ApplicationStub;
@@ -93,5 +95,30 @@ class ParamConverterProviderTest extends TestCase
             // Ensure services are bound
             self::assertInstanceOf($concrete, $application->get($abstract));
         }
+    }
+    /**
+     * Tests register
+     *
+     * @return void
+     */
+    public function testContextConfigurator(): void
+    {
+        $application = new ApplicationStub();
+        $application->bind(ManagerRegistry::class, ManagerRegistryStub::class);
+        $application->bind(AnnotationReaderInterface::class, AnnotationReader::class);
+        $application->bind(ContextConfiguratorInterface::class, ContextConfiguratorStub::class);
+
+        $application->bind(
+            DoctrineDenormalizerEntityFinderInterface::class,
+            DoctrineDenormalizerEntityFinderStub::class
+        );
+
+        // Register services
+        (new ParamConverterProvider($application))->register();
+
+        $application->get(RequestBodyParamConverter::class);
+
+        // Service was created successfully
+        $this->addToAssertionCount(1);
     }
 }

--- a/tests/Stubs/Request/ContextConfiguratorStub.php
+++ b/tests/Stubs/Request/ContextConfiguratorStub.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Stubs\Request;
+
+use FOS\RestBundle\Context\Context;
+use LoyaltyCorp\RequestHandlers\Request\Interfaces\ContextConfiguratorInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @coversNothing
+ */
+class ContextConfiguratorStub implements ContextConfiguratorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(Context $context, Request $request): void
+    {
+        $context->setAttribute('configurated', true);
+    }
+}

--- a/tests/Stubs/Vendor/Symfony/SerializerStub.php
+++ b/tests/Stubs/Vendor/Symfony/SerializerStub.php
@@ -9,6 +9,11 @@ use Throwable;
 class SerializerStub implements SerializerInterface
 {
     /**
+     * @var mixed[]
+     */
+    private $deserialiseCalls = [];
+
+    /**
      * @var mixed|\Throwable
      */
     private $object;
@@ -30,11 +35,23 @@ class SerializerStub implements SerializerInterface
      */
     public function deserialize($data, $type, $format, ?array $context = null)
     {
+        $this->deserialiseCalls[] = \compact('data', 'type', 'format', 'context');
+
         if ($this->object instanceof Throwable) {
             throw $this->object;
         }
 
         return $this->object;
+    }
+
+    /**
+     * Returns calls to deserialise.
+     *
+     * @return mixed[]
+     */
+    public function getDeserialiseCalls(): array
+    {
+        return $this->deserialiseCalls;
     }
 
     /**


### PR DESCRIPTION
This change enables the multi tenancy library to add a configurator to the RequestBodyParamConverter to ensure we have a provider in the serialiser context.

