### PR TITLE
PYMT-1313 Modify DoctrineDenormalizer to support context passing

### DIFF
--- a/src/Serializer/DoctrineDenormalizer.php
+++ b/src/Serializer/DoctrineDenormalizer.php
@@ -88,7 +88,7 @@ final class DoctrineDenormalizer implements DenormalizerInterface
             return null;
         }
 
-        return $this->entityFinder->findOneBy($class, $criteria);
+        return $this->entityFinder->findOneBy($class, $criteria, $context);
     }
 
     /**

--- a/src/Serializer/Interfaces/DoctrineDenormalizerEntityFinderInterface.php
+++ b/src/Serializer/Interfaces/DoctrineDenormalizerEntityFinderInterface.php
@@ -10,8 +10,13 @@ interface DoctrineDenormalizerEntityFinderInterface
      *
      * @param string $class Class name
      * @param mixed[] $criteria Criteria to find an entity
+     * @param mixed[]|null $context
      *
      * @return object|null
      */
-    public function findOneBy(string $class, array $criteria): ?object;
+    public function findOneBy(
+        string $class,
+        array $criteria,
+        ?array $context = null
+    ): ?object;
 }

--- a/tests/Serializer/DoctrineDenormalizerTest.php
+++ b/tests/Serializer/DoctrineDenormalizerTest.php
@@ -48,34 +48,6 @@ class DoctrineDenormalizerTest extends TestCase
     }
 
     /**
-     * Tests denormalize passes context to the entity finder.
-     *
-     * @return void
-     *
-     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerMappingException
-     * @throws \Symfony\Component\Serializer\Exception\ExceptionInterface
-     */
-    public function testDenormalizePassesContext(): void
-    {
-        $registry = $this->createMock(ManagerRegistry::class);
-
-        $finder = new DoctrineDenormalizerEntityFinderStub();
-        $denormalizer = new DoctrineDenormalizer($finder, $registry);
-
-        $expected = [
-            'class' => 'EntityClass',
-            'criteria' => [
-                'externalId' => 'entityId'
-            ],
-            'context' => ['context' => 'array']
-        ];
-
-        $denormalizer->denormalize(['id' => 'entityId'], 'EntityClass', 'json', ['context' => 'array']);
-
-        static::assertSame([$expected], $finder->getCalls());
-    }
-
-    /**
      * Tests denormalize null
      *
      * @return void
@@ -110,6 +82,34 @@ class DoctrineDenormalizerTest extends TestCase
         $denormalizer = new DoctrineDenormalizer($this->createEntityFinder(), $registry);
         $result = $denormalizer->denormalize($entity, 'stdClass');
         self::assertSame($entity, $result);
+    }
+
+    /**
+     * Tests denormalize passes context to the entity finder.
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerMappingException
+     * @throws \Symfony\Component\Serializer\Exception\ExceptionInterface
+     */
+    public function testDenormalizePassesContext(): void
+    {
+        $registry = $this->createMock(ManagerRegistry::class);
+
+        $finder = new DoctrineDenormalizerEntityFinderStub();
+        $denormalizer = new DoctrineDenormalizer($finder, $registry);
+
+        $expected = [
+            'class' => 'EntityClass',
+            'criteria' => [
+                'externalId' => 'entityId'
+            ],
+            'context' => ['context' => 'array']
+        ];
+
+        $denormalizer->denormalize(['id' => 'entityId'], 'EntityClass', 'json', ['context' => 'array']);
+
+        static::assertSame([$expected], $finder->getCalls());
     }
 
     /**

--- a/tests/Serializer/DoctrineDenormalizerTest.php
+++ b/tests/Serializer/DoctrineDenormalizerTest.php
@@ -15,6 +15,8 @@ use Tests\LoyaltyCorp\RequestHandlers\TestCase;
 
 /**
  * @covers \LoyaltyCorp\RequestHandlers\Serializer\DoctrineDenormalizer
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods) Required to test
  */
 class DoctrineDenormalizerTest extends TestCase
 {
@@ -46,69 +48,31 @@ class DoctrineDenormalizerTest extends TestCase
     }
 
     /**
-     * Create entity finder instance
-     *
-     * @param object|null $entity The entity to return on find
-     *
-     * @return \LoyaltyCorp\RequestHandlers\Serializer\Interfaces\DoctrineDenormalizerEntityFinderInterface
-     */
-    private function createEntityFinder(?object $entity = null): DoctrineDenormalizerEntityFinderInterface
-    {
-        return new DoctrineDenormalizerEntityFinderStub($entity);
-    }
-
-    /**
-     * Tests denormalize strings as ID fields.
+     * Tests denormalize passes context to the entity finder.
      *
      * @return void
      *
      * @throws \LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerMappingException
      * @throws \Symfony\Component\Serializer\Exception\ExceptionInterface
      */
-    public function testDenormalizeScalarMatchingId(): void
+    public function testDenormalizePassesContext(): void
     {
-        $entity = new stdClass();
-
         $registry = $this->createMock(ManagerRegistry::class);
 
-        $denormalizer = new DoctrineDenormalizer($this->createEntityFinder($entity), $registry);
-        $result = $denormalizer->denormalize('entityId', 'EntityClass');
-        self::assertSame($entity, $result);
+        $finder = new DoctrineDenormalizerEntityFinderStub();
+        $denormalizer = new DoctrineDenormalizer($finder, $registry);
 
-        $denormalizer = new DoctrineDenormalizer($this->createEntityFinder($entity), $registry);
-        $result = $denormalizer->denormalize(789, 'EntityClass');
-        self::assertSame($entity, $result);
-    }
+        $expected = [
+            'class' => 'EntityClass',
+            'criteria' => [
+                'externalId' => 'entityId'
+            ],
+            'context' => ['context' => 'array']
+        ];
 
-    /**
-     * Tests denormalize strings as ID fields will uses the first custom field if defined.
-     *
-     * @return void
-     *
-     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerMappingException
-     * @throws \Symfony\Component\Serializer\Exception\ExceptionInterface
-     */
-    public function testDenormalizeStringsWithCustomId(): void
-    {
-        $entity = new stdClass();
+        $denormalizer->denormalize(['id' => 'entityId'], 'EntityClass', 'json', ['context' => 'array']);
 
-        $registry = $this->createMock(ManagerRegistry::class);
-
-        $denormalizer = new DoctrineDenormalizer(
-            $this->createEntityFinder($entity),
-            $registry,
-            ['EntityClass' => ['customId' => 'xxx']]
-        );
-        $result = $denormalizer->denormalize('entityIdValue', 'EntityClass');
-        self::assertSame($entity, $result);
-
-        $denormalizer = new DoctrineDenormalizer(
-            $this->createEntityFinder(),
-            $registry,
-            ['EntityClass' => ['abc' => 'xxx', 'yyy' => 'zzz']]
-        );
-        $result = $denormalizer->denormalize('somevalue', 'EntityClass');
-        self::assertSame('somevalue', $result);
+        static::assertSame([$expected], $finder->getCalls());
     }
 
     /**
@@ -149,6 +113,29 @@ class DoctrineDenormalizerTest extends TestCase
     }
 
     /**
+     * Tests denormalize strings as ID fields.
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerMappingException
+     * @throws \Symfony\Component\Serializer\Exception\ExceptionInterface
+     */
+    public function testDenormalizeScalarMatchingId(): void
+    {
+        $entity = new stdClass();
+
+        $registry = $this->createMock(ManagerRegistry::class);
+
+        $denormalizer = new DoctrineDenormalizer($this->createEntityFinder($entity), $registry);
+        $result = $denormalizer->denormalize('entityId', 'EntityClass');
+        self::assertSame($entity, $result);
+
+        $denormalizer = new DoctrineDenormalizer($this->createEntityFinder($entity), $registry);
+        $result = $denormalizer->denormalize(789, 'EntityClass');
+        self::assertSame($entity, $result);
+    }
+
+    /**
      * Tests denormalize scalar that doesn't match anything.
      *
      * @return void
@@ -165,6 +152,37 @@ class DoctrineDenormalizerTest extends TestCase
         $result = $denormalizer->denormalize('purple', 'EntityClass');
 
         self::assertSame('purple', $result);
+    }
+
+    /**
+     * Tests denormalize strings as ID fields will uses the first custom field if defined.
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerMappingException
+     * @throws \Symfony\Component\Serializer\Exception\ExceptionInterface
+     */
+    public function testDenormalizeStringsWithCustomId(): void
+    {
+        $entity = new stdClass();
+
+        $registry = $this->createMock(ManagerRegistry::class);
+
+        $denormalizer = new DoctrineDenormalizer(
+            $this->createEntityFinder($entity),
+            $registry,
+            ['EntityClass' => ['customId' => 'xxx']]
+        );
+        $result = $denormalizer->denormalize('entityIdValue', 'EntityClass');
+        self::assertSame($entity, $result);
+
+        $denormalizer = new DoctrineDenormalizer(
+            $this->createEntityFinder(),
+            $registry,
+            ['EntityClass' => ['abc' => 'xxx', 'yyy' => 'zzz']]
+        );
+        $result = $denormalizer->denormalize('somevalue', 'EntityClass');
+        self::assertSame('somevalue', $result);
     }
 
     /**
@@ -274,5 +292,17 @@ class DoctrineDenormalizerTest extends TestCase
         ], 'CustomerClass');
 
         self::assertFalse($supports);
+    }
+
+    /**
+     * Create entity finder instance
+     *
+     * @param object|null $entity The entity to return on find
+     *
+     * @return \LoyaltyCorp\RequestHandlers\Serializer\Interfaces\DoctrineDenormalizerEntityFinderInterface
+     */
+    private function createEntityFinder(?object $entity = null): DoctrineDenormalizerEntityFinderInterface
+    {
+        return new DoctrineDenormalizerEntityFinderStub($entity);
     }
 }

--- a/tests/Stubs/Builder/ObjectValidatorStub.php
+++ b/tests/Stubs/Builder/ObjectValidatorStub.php
@@ -7,6 +7,9 @@ use LoyaltyCorp\RequestHandlers\Builder\Interfaces\ObjectValidatorInterface;
 use LoyaltyCorp\RequestHandlers\Exceptions\RequestValidationException;
 use LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface;
 
+/**
+ * @coversNothing
+ */
 class ObjectValidatorStub implements ObjectValidatorInterface
 {
     /**

--- a/tests/Stubs/Serializer/DoctrineDenormalizerEntityFinderStub.php
+++ b/tests/Stubs/Serializer/DoctrineDenormalizerEntityFinderStub.php
@@ -11,6 +11,11 @@ use LoyaltyCorp\RequestHandlers\Serializer\Interfaces\DoctrineDenormalizerEntity
 class DoctrineDenormalizerEntityFinderStub implements DoctrineDenormalizerEntityFinderInterface
 {
     /**
+     * @var mixed[]
+     */
+    private $calls;
+
+    /**
      * @var object|null
      */
     private $entity;
@@ -28,8 +33,20 @@ class DoctrineDenormalizerEntityFinderStub implements DoctrineDenormalizerEntity
     /**
      * {@inheritdoc}
      */
-    public function findOneBy(string $class, array $criteria): ?object
+    public function findOneBy(string $class, array $criteria, ?array $context = null): ?object
     {
+        $this->calls[] = \compact('class', 'criteria', 'context');
+
         return $this->entity;
+    }
+
+    /**
+     * Returns calls to findOneBy.
+     *
+     * @return mixed[]
+     */
+    public function getCalls(): array
+    {
+        return $this->calls;
     }
 }


### PR DESCRIPTION
This change makes the denormalizer pass the serialiser context to the entity finder which will allow for custom ProviderEntityFinder