### PR TITLE
PYMT-1220: Add current datetime injection

### DIFF
--- a/src/Bridge/Laravel/Providers/ParamConverterProvider.php
+++ b/src/Bridge/Laravel/Providers/ParamConverterProvider.php
@@ -19,6 +19,7 @@ use LoyaltyCorp\RequestHandlers\Builder\ObjectValidator;
 use LoyaltyCorp\RequestHandlers\Encoder\JsonEncoder;
 use LoyaltyCorp\RequestHandlers\Encoder\XmlEncoder;
 use LoyaltyCorp\RequestHandlers\EventListeners\ParamConverterListener;
+use LoyaltyCorp\RequestHandlers\Request\CurrentDateTimeConverter;
 use LoyaltyCorp\RequestHandlers\Request\DoctrineParamConverter;
 use LoyaltyCorp\RequestHandlers\Request\Interfaces\ContextConfiguratorInterface;
 use LoyaltyCorp\RequestHandlers\Request\Interfaces\ParamConverterManagerInterface;
@@ -143,6 +144,7 @@ final class ParamConverterProvider extends ServiceProvider
             static function (Container $app): ParamConverterManager {
                 $manager = new ParamConverterManager();
                 $manager->add($app->make(RealDoctrineParamConverter::class), 5, null);
+                $manager->add($app->make(CurrentDateTimeConverter::class), 2, null);
                 $manager->add($app->make(RequestBodyParamConverter::class), 1, null);
 
                 return $manager;

--- a/src/Request/CurrentDateTimeConverter.php
+++ b/src/Request/CurrentDateTimeConverter.php
@@ -46,11 +46,8 @@ class CurrentDateTimeConverter implements ParamConverterInterface
             return false;
         }
 
-        if (\is_subclass_of($class, DateTimeInterface::class) ||
-            \is_subclass_of($class, DateTime::class)
-        ) {
-            return true;
-        }
-        return false;
+        return (\is_subclass_of($class, DateTimeInterface::class) === true ||
+            \is_subclass_of($class, DateTime::class) === true
+        );
     }
 }

--- a/src/Request/CurrentDateTimeConverter.php
+++ b/src/Request/CurrentDateTimeConverter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace LoyaltyCorp\RequestHandlers\Request;
 
@@ -7,7 +8,6 @@ use DateTimeInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * Create a date time on demand in controllers.
@@ -23,7 +23,7 @@ class CurrentDateTimeConverter implements ParamConverterInterface
 
         // Don't override existing values.
         if ($request->attributes->has($param) === true &&
-            $value = $request->attributes->get($param) !== null) {
+            $request->attributes->get($param) !== null) {
             return false;
         }
 
@@ -40,12 +40,14 @@ class CurrentDateTimeConverter implements ParamConverterInterface
      */
     public function supports(ParamConverter $configuration)
     {
-        if ($configuration->getClass() === null) {
+        /** @var string|null $class */
+        $class = $configuration->getClass();
+        if ($class === null) {
             return false;
         }
 
-        if (\is_subclass_of($configuration->getClass(), DateTimeInterface::class) ||
-            \is_subclass_of($configuration->getClass(), DateTime::class)
+        if (\is_subclass_of($class, DateTimeInterface::class) ||
+            \is_subclass_of($class, DateTime::class)
         ) {
             return true;
         }

--- a/src/Request/CurrentDateTimeConverter.php
+++ b/src/Request/CurrentDateTimeConverter.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace LoyaltyCorp\RequestHandlers\Request;
+
+use DateTime;
+use DateTimeInterface;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Create a date time on demand in controllers.
+ */
+class CurrentDateTimeConverter implements ParamConverterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function apply(Request $request, ParamConverter $configuration)
+    {
+        $param = $configuration->getName();
+
+        // Don't override existing values.
+        if ($request->attributes->has($param) === true &&
+            $value = $request->attributes->get($param) !== null) {
+            return false;
+        }
+
+        $class = $configuration->getClass();
+        $date = new $class('now');
+
+        $request->attributes->set($param, $date);
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(ParamConverter $configuration)
+    {
+        if ($configuration->getClass() === null) {
+            return false;
+        }
+
+        if (\is_subclass_of($configuration->getClass(), DateTimeInterface::class) ||
+            \is_subclass_of($configuration->getClass(), DateTime::class)
+        ) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/tests/Bridge/Laravel/Providers/ParamConverterProviderTest.php
+++ b/tests/Bridge/Laravel/Providers/ParamConverterProviderTest.php
@@ -10,6 +10,7 @@ use EoneoPay\Utils\Interfaces\AnnotationReaderInterface;
 use LoyaltyCorp\RequestHandlers\Bridge\Laravel\Providers\ParamConverterProvider;
 use LoyaltyCorp\RequestHandlers\Builder\Interfaces\ObjectBuilderInterface;
 use LoyaltyCorp\RequestHandlers\Builder\ObjectBuilder;
+use LoyaltyCorp\RequestHandlers\Request\CurrentDateTimeConverter;
 use LoyaltyCorp\RequestHandlers\Request\DoctrineParamConverter;
 use LoyaltyCorp\RequestHandlers\Request\Interfaces\ContextConfiguratorInterface;
 use LoyaltyCorp\RequestHandlers\Request\RequestBodyParamConverter;
@@ -73,6 +74,7 @@ class ParamConverterProviderTest extends TestCase
             ClassMetadataFactoryInterface::class => ClassMetadataFactory::class,
             ConstraintValidatorFactoryInterface::class => ContainerConstraintValidatorFactory::class,
             ControllerListener::class => ControllerListener::class,
+            CurrentDateTimeConverter::class => CurrentDateTimeConverter::class,
             DivisibleByValidator::class => DivisibleByValidator::class,
             EqualToValidator::class => EqualToValidator::class,
             GreaterThanOrEqualValidator::class => GreaterThanOrEqualValidator::class,

--- a/tests/Request/CurrentDateTimeConverterTest.php
+++ b/tests/Request/CurrentDateTimeConverterTest.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Request;
+
+use DateTime as BaseDateTime;
+use EoneoPay\Utils\DateTime;
+use LoyaltyCorp\RequestHandlers\Request\CurrentDateTimeConverter;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Symfony\Component\HttpFoundation\Request;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\RequestHandlers\Request\CurrentDateTimeConverter
+ */
+class CurrentDateTimeConverterTest extends TestCase
+{
+    /**
+     * Test the application of the DateTime field.
+     */
+    public function testApply(): void
+    {
+        $request = new Request([]);
+        $param = new ParamConverter(['class' => DateTime::class, 'name' => 'now']);
+        $converter = $this->getConverter();
+
+        $response = $converter->apply($request, $param);
+
+        self::assertTrue($response);
+        self::assertInstanceOf(DateTime::class, $request->attributes->get('now'));
+    }
+
+    /**
+     * Test skipping the application of the datetime field that is already filled.
+     */
+    public function testFailingApply(): void
+    {
+        $request = new Request([], [], ['now' => 'already set']);
+        $param = new ParamConverter(['class' => DateTime::class, 'name' => 'now']);
+        $converter = $this->getConverter();
+
+        $response = $converter->apply($request, $param);
+
+        self::assertFalse($response);
+        self::assertNull($request->attributes->get('already set'));
+    }
+
+    /**
+     * Test that returning a BaseDateTime is supported.
+     */
+    public function testSupportsBaseDateTime(): void
+    {
+        $param = new ParamConverter(['class' => BaseDateTime::class]);
+        $converter = $this->getConverter();
+
+        $supports = $converter->supports($param);
+
+        self::assertTrue($supports);
+    }
+
+    /**
+     * Test that returning a EoneoPayUtils datetime is supported.
+     */
+    public function testSupportsEoneoPayDateTime(): void
+    {
+        $param = new ParamConverter(['class' => DateTime::class]);
+        $converter = $this->getConverter();
+
+        $supports = $converter->supports($param);
+
+        self::assertTrue($supports);
+    }
+
+    private function getConverter(): CurrentDateTimeConverter
+    {
+        return new CurrentDateTimeConverter();
+    }
+}

--- a/tests/Request/CurrentDateTimeConverterTest.php
+++ b/tests/Request/CurrentDateTimeConverterTest.php
@@ -17,6 +17,8 @@ class CurrentDateTimeConverterTest extends TestCase
 {
     /**
      * Test the application of the DateTime field.
+     *
+     * @return void
      */
     public function testApply(): void
     {
@@ -32,6 +34,8 @@ class CurrentDateTimeConverterTest extends TestCase
 
     /**
      * Test skipping the application of the datetime field that is already filled.
+     *
+     * @return void
      */
     public function testFailingApply(): void
     {
@@ -47,6 +51,8 @@ class CurrentDateTimeConverterTest extends TestCase
 
     /**
      * Test that returning a BaseDateTime is supported.
+     *
+     * @return void
      */
     public function testSupportsBaseDateTime(): void
     {
@@ -60,6 +66,8 @@ class CurrentDateTimeConverterTest extends TestCase
 
     /**
      * Test that returning a EoneoPayUtils datetime is supported.
+     *
+     * @return void
      */
     public function testSupportsEoneoPayDateTime(): void
     {
@@ -71,6 +79,11 @@ class CurrentDateTimeConverterTest extends TestCase
         self::assertTrue($supports);
     }
 
+    /**
+     * Get a CurrentDateTimeConverter for testing.
+     *
+     * @return \LoyaltyCorp\RequestHandlers\Request\CurrentDateTimeConverter
+     */
     private function getConverter(): CurrentDateTimeConverter
     {
         return new CurrentDateTimeConverter();

--- a/tests/Request/CurrentDateTimeConverterTest.php
+++ b/tests/Request/CurrentDateTimeConverterTest.php
@@ -7,6 +7,7 @@ use DateTime as BaseDateTime;
 use EoneoPay\Utils\DateTime;
 use LoyaltyCorp\RequestHandlers\Request\CurrentDateTimeConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use stdClass;
 use Symfony\Component\HttpFoundation\Request;
 use Tests\LoyaltyCorp\RequestHandlers\TestCase;
 
@@ -77,6 +78,36 @@ class CurrentDateTimeConverterTest extends TestCase
         $supports = $converter->supports($param);
 
         self::assertTrue($supports);
+    }
+
+    /**
+     * Test that returning a non-datetime classes are not supported.
+     *
+     * @return void
+     */
+    public function testNotSupportsNonDateTime(): void
+    {
+        $param = new ParamConverter(['class' => stdClass::class]);
+        $converter = $this->getConverter();
+
+        $supports = $converter->supports($param);
+
+        self::assertFalse($supports);
+    }
+
+    /**
+     * Test that a missing class definition is not supported.
+     *
+     * @return void
+     */
+    public function testFalseForMissingClass(): void
+    {
+        $param = new ParamConverter([]);
+        $converter = $this->getConverter();
+
+        $supports = $converter->supports($param);
+
+        self::assertFalse($supports);
     }
 
     /**


### PR DESCRIPTION
Supports the following:


```php
     /**
     * @ParamConverter("now", class="EoneoPay\Utils\DateTime")
     */
    public function get(DateTime $now): SecondaryActionResponse
    {
        return $this->responseFactory->create($now);
    }
```