### PR TITLE
PYMT-369: Addition of entity finder class

### DIFF
--- a/src/Exceptions/DoctrineDenormalizerEntityFinderClassException.php
+++ b/src/Exceptions/DoctrineDenormalizerEntityFinderClassException.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Exceptions;
+
+use EoneoPay\Utils\Exceptions\BaseException;
+
+class DoctrineDenormalizerEntityFinderClassException extends BaseException
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorCode(): int
+    {
+        return 31;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorSubCode(): int
+    {
+        return 1;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStatusCode(): int
+    {
+        return static::DEFAULT_STATUS_CODE_RUNTIME;
+    }
+}

--- a/src/Serializer/DoctrineDenormalizerEntityFinder.php
+++ b/src/Serializer/DoctrineDenormalizerEntityFinder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace LoyaltyCorp\RequestHandlers\Serializer;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\Common\Persistence\ObjectRepository;
 use LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerEntityFinderClassException;
 use LoyaltyCorp\RequestHandlers\Serializer\Interfaces\DoctrineDenormalizerEntityFinderInterface;
 
@@ -49,19 +48,6 @@ class DoctrineDenormalizerEntityFinder implements DoctrineDenormalizerEntityFind
         }
 
         $repository = $this->entityManager->getRepository($class);
-
-        // @codeCoverageIgnoreStart
-        // Ignored as there is no efficient way to test this.
-        if (($repository instanceof ObjectRepository) === false) {
-            return null;
-        }
-        // @codeCoverageIgnoreEnd
-
-        /**
-         * @var \Doctrine\Common\Persistence\ObjectRepository $repository
-         *
-         * @see https://youtrack.jetbrains.com/issue/WI-37859 - typehint required until PhpStorm recognises === chek
-         */
 
         return $repository->findOneBy($criteria);
     }

--- a/src/Serializer/DoctrineDenormalizerEntityFinder.php
+++ b/src/Serializer/DoctrineDenormalizerEntityFinder.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\RequestHandlers\Serializer;
+
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\ObjectRepository;
+use LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerEntityFinderClassException;
+use LoyaltyCorp\RequestHandlers\Serializer\Interfaces\DoctrineDenormalizerEntityFinderInterface;
+
+class DoctrineDenormalizerEntityFinder implements DoctrineDenormalizerEntityFinderInterface
+{
+    /**
+     * @var \Doctrine\Common\Persistence\ManagerRegistry
+     */
+    private $entityManager;
+
+    /**
+     * Create entity finder.
+     *
+     * @param \Doctrine\Common\Persistence\ManagerRegistry $entityManager
+     */
+    public function __construct(ManagerRegistry $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * Find an entity by given criteria.
+     *
+     * @param string $class
+     * @param mixed[] $criteria
+     * @param mixed[]|null $context
+     *
+     * @return object|null
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerEntityFinderClassException
+     *
+     * @phpstan-param class-string $class
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) Unused context
+     */
+    public function findOneBy(string $class, array $criteria, ?array $context = null): ?object
+    {
+        if (\class_exists($class) === false) {
+            throw new DoctrineDenormalizerEntityFinderClassException(
+                \sprintf('The class "%s" could not be found.', $class)
+            );
+        }
+
+        $repository = $this->entityManager->getRepository($class);
+
+        // @codeCoverageIgnoreStart
+        // Ignored as there is no efficient way to test this.
+        if (($repository instanceof ObjectRepository) === false) {
+            return null;
+        }
+        // @codeCoverageIgnoreEnd
+
+        /**
+         * @var \Doctrine\Common\Persistence\ObjectRepository $repository
+         *
+         * @see https://youtrack.jetbrains.com/issue/WI-37859 - typehint required until PhpStorm recognises === chek
+         */
+
+        return $repository->findOneBy($criteria);
+    }
+}

--- a/tests/Exceptions/DoctrineDenormalizerEntityFinderClassExceptionTest.php
+++ b/tests/Exceptions/DoctrineDenormalizerEntityFinderClassExceptionTest.php
@@ -7,7 +7,7 @@ use LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerEntityFinderClass
 use Tests\LoyaltyCorp\RequestHandlers\TestCase;
 
 /**
- * @covers \LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerMappingException
+ * @covers \LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerEntityFinderClassException
  */
 class DoctrineDenormalizerEntityFinderClassExceptionTest extends TestCase
 {

--- a/tests/Exceptions/DoctrineDenormalizerEntityFinderClassExceptionTest.php
+++ b/tests/Exceptions/DoctrineDenormalizerEntityFinderClassExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Exceptions;
+
+use LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerEntityFinderClassException;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerMappingException
+ */
+class DoctrineDenormalizerEntityFinderClassExceptionTest extends TestCase
+{
+    /**
+     * Tests that the error codes on the expection match the expected.
+     *
+     * @return void
+     */
+    public function testExceptionMethods(): void
+    {
+        $exception = new DoctrineDenormalizerEntityFinderClassException();
+
+        self::assertSame(1, $exception->getErrorSubCode());
+        self::assertSame(31, $exception->getErrorCode());
+        self::assertSame(500, $exception->getStatusCode());
+    }
+}

--- a/tests/Serializer/DoctrineDenormalizerEntityFinderTest.php
+++ b/tests/Serializer/DoctrineDenormalizerEntityFinderTest.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Serializer;
+
+use LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerEntityFinderClassException;
+use LoyaltyCorp\RequestHandlers\Serializer\DoctrineDenormalizerEntityFinder;
+use stdClass;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Doctrine\Common\Persistence\ManagerRegistryStub;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Doctrine\Common\Persistence\ObjectRepositoryStub;
+use Tests\LoyaltyCorp\RequestHandlers\TestCase;
+
+class DoctrineDenormalizerEntityFinderTest extends TestCase
+{
+    /**
+     * Tests that the 'findOneBy' method returns null when a repository is not found for the specified class.
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerEntityFinderClassException
+     */
+    public function testFindOneByReturnsNullOnMissingRepository(): void
+    {
+        $registry = new ManagerRegistryStub(null);
+        $instance = new DoctrineDenormalizerEntityFinder($registry);
+
+        $result = $instance->findOneBy(stdClass::class, []);
+
+        self::assertNull($result);
+    }
+
+    /**
+     * Tests that the 'findOneBy' successfully returns an entity when the correct repository instance is used.
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerEntityFinderClassException
+     */
+    public function testFindOneBySuccessful(): void
+    {
+        $entity = new stdClass();
+        $repository = new ObjectRepositoryStub([$entity]);
+        $registry = new ManagerRegistryStub($repository);
+        $instance = new DoctrineDenormalizerEntityFinder($registry);
+
+        $result = $instance->findOneBy(stdClass::class, []);
+
+        self::assertSame($entity, $result);
+    }
+
+    /**
+     * Tests that the 'findOneBy' method throws an exception when the provided class does not exist.
+     *
+     * @return void
+     *
+     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerEntityFinderClassException
+     */
+    public function testFindOneByThrowsExceptionWithNonExistentClass(): void
+    {
+        $registry = new ManagerRegistryStub(null);
+        $instance = new DoctrineDenormalizerEntityFinder($registry);
+
+        $this->expectException(DoctrineDenormalizerEntityFinderClassException::class);
+        $this->expectExceptionMessage('The class "ThisIsNotARealClass" could not be found.');
+
+        $instance->findOneBy('ThisIsNotARealClass', []);
+    }
+}

--- a/tests/Serializer/DoctrineDenormalizerEntityFinderTest.php
+++ b/tests/Serializer/DoctrineDenormalizerEntityFinderTest.php
@@ -13,23 +13,6 @@ use Tests\LoyaltyCorp\RequestHandlers\TestCase;
 class DoctrineDenormalizerEntityFinderTest extends TestCase
 {
     /**
-     * Tests that the 'findOneBy' method returns null when a repository is not found for the specified class.
-     *
-     * @return void
-     *
-     * @throws \LoyaltyCorp\RequestHandlers\Exceptions\DoctrineDenormalizerEntityFinderClassException
-     */
-    public function testFindOneByReturnsNullOnMissingRepository(): void
-    {
-        $registry = new ManagerRegistryStub(null);
-        $instance = new DoctrineDenormalizerEntityFinder($registry);
-
-        $result = $instance->findOneBy(stdClass::class, []);
-
-        self::assertNull($result);
-    }
-
-    /**
      * Tests that the 'findOneBy' successfully returns an entity when the correct repository instance is used.
      *
      * @return void

--- a/tests/Stubs/Vendor/Doctrine/Common/Persistence/ManagerRegistryStub.php
+++ b/tests/Stubs/Vendor/Doctrine/Common/Persistence/ManagerRegistryStub.php
@@ -5,8 +5,26 @@ namespace Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Doctrine\Common\Persist
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 
+/**
+ * @coversNothing
+ */
 class ManagerRegistryStub implements ManagerRegistry
 {
+    /**
+     * @var mixed|null
+     */
+    private $objectRepository;
+
+    /**
+     * Constructs a new instance of ManagerRegistryStub.
+     *
+     * @param mixed $objectRepository
+     */
+    public function __construct($objectRepository = null)
+    {
+        $this->objectRepository = $objectRepository;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -85,6 +103,7 @@ class ManagerRegistryStub implements ManagerRegistry
      */
     public function getRepository($persistentObject, $persistentManagerName = null)
     {
+        return $this->objectRepository;
     }
 
     /**

--- a/tests/Stubs/Vendor/Doctrine/Common/Persistence/ObjectRepositoryStub.php
+++ b/tests/Stubs/Vendor/Doctrine/Common/Persistence/ObjectRepositoryStub.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Stubs\Vendor\Doctrine\Common\Persistence;
+
+use Doctrine\Common\Persistence\ObjectRepository;
+
+/**
+ * @coversNothing
+ */
+class ObjectRepositoryStub implements ObjectRepository
+{
+    /**
+     * @var mixed[]
+     */
+    private $entities;
+
+    /**
+     * Constructs a new instance of ObjectRepositoryStub.
+     *
+     * @param mixed[]|null $entities
+     */
+    public function __construct(?array $entities = null)
+    {
+        $this->entities = $entities ?? [];
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @SuppressWarnings(PHPMD.ShortVariable) Parameter is inherited from interface
+     */
+    public function find($id): ?object
+    {
+        return \reset($this->entities);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findAll(): array
+    {
+        return $this->entities;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null): array
+    {
+        return $this->entities;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findOneBy(array $criteria): ?object
+    {
+        $entity = \reset($this->entities);
+
+        if ($entity === false) {
+            return null;
+        }
+
+        return $entity;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClassName(): string
+    {
+        return self::class;
+    }
+}


### PR DESCRIPTION
This PR adds an entity finder class to the package along with tests to cover.

It is to be used in payments for PYMT-369 (nominal overrides).

**Related PR:** https://github.com/eonx-com/payments/pull/435
**Related ticket:** https://eonx.atlassian.net/browse/PAY-369