### PR TITLE
PAY-1608 Handle issues with Discriminators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+*.cache

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "symfony/validator": "^4.4"
   },
   "require-dev": {
-    "eonx-com/standards": "^0.2",
+    "eonx-com/standards": "^0.3",
     "phpmd/phpmd": "^2.6,!=2.7.0",
     "phpstan/phpstan": "^0.11.6",
     "phpstan/phpstan-phpunit": "^0.11.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "77098abac48e938fb00281f64aecb2f4",
+    "content-hash": "14632d754284e92d64be7391a946c70e",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -5852,16 +5852,16 @@
         },
         {
             "name": "eonx-com/standards",
-            "version": "v0.2.3",
+            "version": "v0.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/eonx-com/standards.git",
-                "reference": "e04a85fc3c1f2a34c1af8c991e2b544b1c9e6eeb"
+                "reference": "57cd574d00cf00872ecf90562d2ba1538e3b0076"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/eonx-com/standards/zipball/e04a85fc3c1f2a34c1af8c991e2b544b1c9e6eeb",
-                "reference": "e04a85fc3c1f2a34c1af8c991e2b544b1c9e6eeb",
+                "url": "https://api.github.com/repos/eonx-com/standards/zipball/57cd574d00cf00872ecf90562d2ba1538e3b0076",
+                "reference": "57cd574d00cf00872ecf90562d2ba1538e3b0076",
                 "shasum": ""
             },
             "require": {
@@ -5905,7 +5905,7 @@
                 "eoneopay",
                 "standards"
             ],
-            "time": "2019-12-05T03:38:07+00:00"
+            "time": "2020-01-14T02:53:45+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",

--- a/tests/Bridge/Laravel/Providers/ParamConverterProviderTest.php
+++ b/tests/Bridge/Laravel/Providers/ParamConverterProviderTest.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 namespace Tests\LoyaltyCorp\RequestHandlers\Bridge\Laravel\Providers;
 
 use Doctrine\Common\Annotations\Reader;
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\ManagerRegistry as CommonManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use EoneoPay\Utils\AnnotationReader;
 use EoneoPay\Utils\Interfaces\AnnotationReaderInterface;
 use LoyaltyCorp\RequestHandlers\Bridge\Laravel\Providers\ParamConverterProvider;
@@ -56,7 +57,9 @@ class ParamConverterProviderTest extends TestCase
     public function testRegister(): void
     {
         $application = new ApplicationStub();
-        $application->bind(ManagerRegistry::class, ManagerRegistryStub::class);
+        $registry = new ManagerRegistryStub();
+        $application->instance(ManagerRegistry::class, $registry);
+        $application->instance(CommonManagerRegistry::class, $registry);
         $application->bind(AnnotationReaderInterface::class, AnnotationReader::class);
 
         $application->bind(
@@ -106,7 +109,9 @@ class ParamConverterProviderTest extends TestCase
     public function testContextConfigurator(): void
     {
         $application = new ApplicationStub();
-        $application->bind(ManagerRegistry::class, ManagerRegistryStub::class);
+        $registry = new ManagerRegistryStub();
+        $application->instance(ManagerRegistry::class, $registry);
+        $application->instance(CommonManagerRegistry::class, $registry);
         $application->bind(AnnotationReaderInterface::class, AnnotationReader::class);
         $application->bind(ContextConfiguratorInterface::class, ContextConfiguratorStub::class);
 

--- a/tests/Bridge/Laravel/Providers/ParamConverterProviderTest.php
+++ b/tests/Bridge/Laravel/Providers/ParamConverterProviderTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 namespace Tests\LoyaltyCorp\RequestHandlers\Bridge\Laravel\Providers;
 
 use Doctrine\Common\Annotations\Reader;
-use Doctrine\Common\Persistence\ManagerRegistry as CommonManagerRegistry;
-use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\ManagerRegistry;
 use EoneoPay\Utils\AnnotationReader;
 use EoneoPay\Utils\Interfaces\AnnotationReaderInterface;
 use LoyaltyCorp\RequestHandlers\Bridge\Laravel\Providers\ParamConverterProvider;
@@ -59,7 +58,6 @@ class ParamConverterProviderTest extends TestCase
         $application = new ApplicationStub();
         $registry = new ManagerRegistryStub();
         $application->instance(ManagerRegistry::class, $registry);
-        $application->instance(CommonManagerRegistry::class, $registry);
         $application->bind(AnnotationReaderInterface::class, AnnotationReader::class);
 
         $application->bind(
@@ -111,7 +109,6 @@ class ParamConverterProviderTest extends TestCase
         $application = new ApplicationStub();
         $registry = new ManagerRegistryStub();
         $application->instance(ManagerRegistry::class, $registry);
-        $application->instance(CommonManagerRegistry::class, $registry);
         $application->bind(AnnotationReaderInterface::class, AnnotationReader::class);
         $application->bind(ContextConfiguratorInterface::class, ContextConfiguratorStub::class);
 

--- a/tests/Fixtures/DiscriminatedRequest.php
+++ b/tests/Fixtures/DiscriminatedRequest.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Fixtures;
+
+use LoyaltyCorp\RequestHandlers\Request\RequestObjectInterface;
+use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+use Symfony\Component\Validator\Constraints as Assert;
+use Tests\LoyaltyCorp\RequestHandlers\Stubs\Exceptions\RequestValidationExceptionStub;
+
+/**
+ * @DiscriminatorMap(mapping={
+ *     "sub" = "Tests\LoyaltyCorp\RequestHandlers\Fixtures\SubDiscriminatedRequest"
+ * }, typeProperty="type")
+ */
+class DiscriminatedRequest implements RequestObjectInterface
+{
+    /**
+     * @Assert\Type("string")
+     *
+     * @var mixed
+     */
+    private $property;
+
+    /**
+     * @Assert\Type("string")
+     *
+     * @var string
+     */
+    private $type;
+
+    /**
+     * Constructor
+     *
+     * @param mixed $property
+     */
+    public function __construct($property = null)
+    {
+        $this->property = $property;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getExceptionClass(): string
+    {
+        return RequestValidationExceptionStub::class;
+    }
+
+    /**
+     * Returns the property
+     *
+     * @return mixed
+     */
+    public function getProperty()
+    {
+        return $this->property;
+    }
+
+    /**
+     * Returns the type.
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolveValidationGroups(): array
+    {
+        return [];
+    }
+}

--- a/tests/Fixtures/SubDiscriminatedRequest.php
+++ b/tests/Fixtures/SubDiscriminatedRequest.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\RequestHandlers\Fixtures;
+
+class SubDiscriminatedRequest extends DiscriminatedRequest
+{
+}

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -3,8 +3,7 @@ declare(strict_types=1);
 
 namespace Tests\LoyaltyCorp\RequestHandlers\Integration;
 
-use Doctrine\Common\Persistence\ManagerRegistry as CommonManagerRegistry;
-use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\ManagerRegistry;
 use EoneoPay\Utils\AnnotationReader;
 use EoneoPay\Utils\DateTime;
 use EoneoPay\Utils\Interfaces\AnnotationReaderInterface;
@@ -373,7 +372,6 @@ VIOLATIONS;
         $app->bind(DoctrineDenormalizerEntityFinderInterface::class, DoctrineDenormalizerEntityFinderStub::class);
         $registry = new ManagerRegistryStub();
         $app->instance(ManagerRegistry::class, $registry);
-        $app->instance(CommonManagerRegistry::class, $registry);
         (new ParamConverterProvider($app))->register();
         $app->bind(AnnotationReaderInterface::class, AnnotationReader::class);
 

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -3,7 +3,8 @@ declare(strict_types=1);
 
 namespace Tests\LoyaltyCorp\RequestHandlers\Integration;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\ManagerRegistry as CommonManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use EoneoPay\Utils\AnnotationReader;
 use EoneoPay\Utils\DateTime;
 use EoneoPay\Utils\Interfaces\AnnotationReaderInterface;
@@ -370,7 +371,9 @@ VIOLATIONS;
         $app = new ApplicationStub();
         $app->instance(Container::class, $app);
         $app->bind(DoctrineDenormalizerEntityFinderInterface::class, DoctrineDenormalizerEntityFinderStub::class);
-        $app->bind(ManagerRegistry::class, ManagerRegistryStub::class);
+        $registry = new ManagerRegistryStub();
+        $app->instance(ManagerRegistry::class, $registry);
+        $app->instance(CommonManagerRegistry::class, $registry);
         (new ParamConverterProvider($app))->register();
         $app->bind(AnnotationReaderInterface::class, AnnotationReader::class);
 

--- a/tests/Integration/SerialisableResponseMiddlewareTest.php
+++ b/tests/Integration/SerialisableResponseMiddlewareTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 namespace Tests\LoyaltyCorp\RequestHandlers\Integration;
 
 use Closure;
-use Doctrine\Common\Persistence\ManagerRegistry as CommonManagerRegistry;
-use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\ManagerRegistry;
 use EoneoPay\ApiFormats\Bridge\Laravel\Responses\FormattedApiResponse;
 use EoneoPay\Utils\AnnotationReader;
 use EoneoPay\Utils\Interfaces\AnnotationReaderInterface;
@@ -100,7 +99,6 @@ class SerialisableResponseMiddlewareTest extends TestCase
         $app->bind(DoctrineDenormalizerEntityFinderInterface::class, DoctrineDenormalizerEntityFinderStub::class);
         $registry = new ManagerRegistryStub();
         $app->instance(ManagerRegistry::class, $registry);
-        $app->instance(CommonManagerRegistry::class, $registry);
         $app->bind(AnnotationReaderInterface::class, AnnotationReader::class);
         (new ParamConverterProvider($app))->register();
         (new SerialisableResponseProvider($app))->register();

--- a/tests/Integration/SerialisableResponseMiddlewareTest.php
+++ b/tests/Integration/SerialisableResponseMiddlewareTest.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 namespace Tests\LoyaltyCorp\RequestHandlers\Integration;
 
 use Closure;
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\ManagerRegistry as CommonManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use EoneoPay\ApiFormats\Bridge\Laravel\Responses\FormattedApiResponse;
 use EoneoPay\Utils\AnnotationReader;
 use EoneoPay\Utils\Interfaces\AnnotationReaderInterface;
@@ -97,7 +98,9 @@ class SerialisableResponseMiddlewareTest extends TestCase
         $app = new ApplicationStub();
         $app->instance(Container::class, $app);
         $app->bind(DoctrineDenormalizerEntityFinderInterface::class, DoctrineDenormalizerEntityFinderStub::class);
-        $app->bind(ManagerRegistry::class, ManagerRegistryStub::class);
+        $registry = new ManagerRegistryStub();
+        $app->instance(ManagerRegistry::class, $registry);
+        $app->instance(CommonManagerRegistry::class, $registry);
         $app->bind(AnnotationReaderInterface::class, AnnotationReader::class);
         (new ParamConverterProvider($app))->register();
         (new SerialisableResponseProvider($app))->register();


### PR DESCRIPTION
When using discriminated objects with the serialiser, it will throw an exception if the type property is missing or contains a value that is not mapped.

This is not ideal for request objects - if the input request is invalid we get a 500 exception instead of being able to handle it in our custom validation layer.

This PR changes the way the serialiser deals with creation of objects and will create the base object of the discriminator when no type can be resolved from the input data.

*This means all discriminated request objects must not be abstract*.